### PR TITLE
Resolve issue #7 wait: error running audit command exit status 1.

### DIFF
--- a/cfg/federated.yaml
+++ b/cfg/federated.yaml
@@ -9,7 +9,7 @@ groups:
   checks:
      - id: 3.1.1
        text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
            - flag: "--anonymous-auth"
@@ -23,7 +23,7 @@ groups:
 
      - id: 3.1.2
        text: "Ensure that the --basic-auth-file argument is not set (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
            - flag: "--basic-auth-file"
@@ -35,7 +35,7 @@ groups:
   
      - id: 3.1.3
        text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
            - flag: "--insecure-allow-any-token"
@@ -46,7 +46,7 @@ groups:
  
      - id: 3.1.4
        text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
            - flag: "--insecure-bind-address"
@@ -57,7 +57,7 @@ groups:
 
      - id: 3.1.5
        text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--insecure-port"
@@ -71,7 +71,7 @@ groups:
 
      - id: 3.1.6
        text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests: 
          bin_op: or
          test_items:
@@ -88,7 +88,7 @@ groups:
 
      - id: 3.1.7
        text: "Ensure that the --profiling argument is set to false (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--profiling"
@@ -102,7 +102,7 @@ groups:
 
      - id: 3.1.8
        text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--admission-control"
@@ -117,7 +117,7 @@ groups:
 
      - id: 3.1.9
        text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "admission-control"
@@ -131,7 +131,7 @@ groups:
 
      - id: 3.1.10
        text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--audit-log-path"
@@ -142,7 +142,7 @@ groups:
   
      - id: 3.1.11
        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--audit-log-maxage"
@@ -156,7 +156,7 @@ groups:
                
      - id: 3.1.12
        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--audit-log-maxbackup"
@@ -170,7 +170,7 @@ groups:
 
      - id: 3.1.13
        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--audit-log-maxsize"
@@ -184,7 +184,7 @@ groups:
 
      - id: 3.1.14
        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--authorization-mode"
@@ -198,7 +198,7 @@ groups:
  
      - id: 3.1.15
        text: "Ensure that the --token-auth-file parameter is not set (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--token-auth-file"
@@ -210,7 +210,7 @@ groups:
   
      - id: 3.1.16
        text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--service-account-lookup"
@@ -224,7 +224,7 @@ groups:
 
      - id: 3.1.17
        text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--service-account-key-file"
@@ -235,7 +235,7 @@ groups:
 
      - id: 3.1.18
        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          bin_op: and
          test_items:
@@ -252,7 +252,7 @@ groups:
 
      - id: 3.1.19
        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
-       audit: "ps -ef | grep federation-apiserver | grep -v grep"
+       audit: "ps -C federation-apiserver -o cmd --no-headers"
        tests:
          bin_op: and
          test_items:
@@ -271,7 +271,7 @@ groups:
   checks:
      - id: 3.2.1
        text: "Ensure that the --profiling argument is set to false (Scored)"
-       audit: "ps -ef | grep federation-controller-manager | grep -v grep"
+       audit: "ps -C federation-controller-manager -o cmd --no-headers"
        tests:
          test_items:
          - flag: "--profiling"

--- a/cfg/master.yaml
+++ b/cfg/master.yaml
@@ -9,7 +9,7 @@ groups:
   checks:
     - id: 1.1.1
       text: "Ensure that the --allow-privileged argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "allow-privileged"
@@ -23,7 +23,7 @@ groups:
 
     - id: 1.1.2
       text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--anonymous-auth"
@@ -37,7 +37,7 @@ groups:
 
     - id: 1.1.3
       text: "Ensure that the --basic-auth-file argument is not set (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--basic-auth-file"
@@ -50,7 +50,7 @@ groups:
 
     - id: 1.1.4
       text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag:  "--insecure-allow-any-token"
@@ -61,7 +61,7 @@ groups:
 
     - id: 1.1.5
       text: "Ensure that the --kubelet-https argument is set to true (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests: 
         bin_op: or
         test_items:
@@ -78,7 +78,7 @@ groups:
 
     - id: 1.1.6
       text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--insecure-bind-address"
@@ -89,7 +89,7 @@ groups:
 
     - id: 1.1.7
       text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--insecure-port"
@@ -103,7 +103,7 @@ groups:
 
     - id: 1.1.8
       text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests: 
         bin_op: or
         test_items:
@@ -121,7 +121,7 @@ groups:
 
     - id: 1.1.9
       text: "Ensure that the --profiling argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--profiling"
@@ -135,7 +135,7 @@ groups:
 
     - id: 1.1.10
       text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--repair-malformed-updates"
@@ -149,7 +149,7 @@ groups:
 
     - id: 1.1.11
       text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -163,7 +163,7 @@ groups:
  
     - id: 1.1.12
       text: "Ensure that the admission control policy is set to AlwaysPullImages (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -177,7 +177,7 @@ groups:
  
     - id: 1.1.13
       text: "Ensure that the admission control policy is set to DenyEscalatingExec (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -191,7 +191,7 @@ groups:
 
     - id: 1.1.14
       text: "Ensure that the admission control policy is set to SecurityContextDeny (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -205,7 +205,7 @@ groups:
 
     - id: 1.1.15
       text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "admission-control"
@@ -219,7 +219,7 @@ groups:
 
     - id: 1.1.16
       text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--audit-log-path"
@@ -230,7 +230,7 @@ groups:
 
     - id: 1.1.17
       text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--audit-log-maxage"
@@ -244,7 +244,7 @@ groups:
 
     - id: 1.1.18
       text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--audit-log-maxbackup"
@@ -258,7 +258,7 @@ groups:
 
     - id: 1.1.19
       text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--audit-log-maxsize"
@@ -272,7 +272,7 @@ groups:
 
     - id: 1.1.20
       text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--authorization-mode"
@@ -286,7 +286,7 @@ groups:
 
     - id: 1.1.21
       text: "Ensure that the --token-auth-file parameter is not set (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--token-auth-file"
@@ -298,7 +298,7 @@ groups:
  
     - id: 1.1.22
       text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--kubelet-certificate-authority"
@@ -311,7 +311,7 @@ groups:
 
     - id: 1.1.23
       text: "Ensure that the --kubelet-client-certificate and --kubelet-clientkey arguments are set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         bin_op: and
         test_items:
@@ -327,7 +327,7 @@ groups:
 
     - id: 1.1.24
       text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--service-account-lookup"
@@ -341,7 +341,7 @@ groups:
  
     - id: 1.1.25
       text: "Ensure that the admission control policy is set to PodSecurityPolicy (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -356,7 +356,7 @@ groups:
 
     - id: 1.1.26
       text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--service-account-key-file"
@@ -367,7 +367,7 @@ groups:
 
     - id: 1.1.27
       text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         bin_op: and
         test_items:
@@ -383,7 +383,7 @@ groups:
  
     - id: 1.1.28
       text: "Ensure that the admission control policy is set to ServiceAccount (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--admission-control"
@@ -398,7 +398,7 @@ groups:
 
     - id: 1.1.29
       text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         bin_op: and
         test_items:
@@ -414,7 +414,7 @@ groups:
 
     - id: 1.1.30
       text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--client-ca-file"
@@ -426,7 +426,7 @@ groups:
 
     - id: 1.1.31
       text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-apiserver | grep -v grep"
+      audit: "ps -C kube-apiserver -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--etcd-cafile"
@@ -441,7 +441,7 @@ groups:
   checks:
     - id: 1.2.1
       text: "Ensure that the --profiling argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-scheduler | grep -v grep"
+      audit: "ps -C kube-scheduler -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--profiling"
@@ -458,7 +458,7 @@ groups:
   checks:
     - id: 1.3.1
       text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--terminated-pod-gc-threshold"
@@ -469,7 +469,7 @@ groups:
  
     - id: 1.3.2
       text: "Ensure that the --profiling argument is set to false (Scored)"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--profiling"
@@ -483,7 +483,7 @@ groups:
  
     - id: 1.3.3
       text: "Ensure that the --insecure-experimental-approve-all-kubelet-csrs-for-group argument is not set (Scored)"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--insecure-experimental-approve-all-kubelet-csrs-for-group"
@@ -495,7 +495,7 @@ groups:
 
     - id: 1.3.4
       text: "Ensure that the --use-service-account-credentials argument is set"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--use-service-account-credentials"
@@ -509,7 +509,7 @@ groups:
 
     - id: 1.3.5
       text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--service-account-private-key-file"
@@ -520,7 +520,7 @@ groups:
 
     - id: 1.3.6
       text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kube-controller-manager | grep -v grep"
+      audit: "ps -C kube-controller-manager -o cmd --no-headers"
       tests:
         test_items:
         - flag: "--root-ca-file"
@@ -644,9 +644,7 @@ groups:
       
     - id: 1.4.11
       text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-      # audit: ps -ef | grep etcd | grep -v grep | sed 's,.*--data-dir=\(.*\)\s*.*,\1,' | xargs stat -c %a
-      audit: "ps -ef | grep etcd | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
-      # audit: xargs stat -c %a /etc/etcd
+      audit: "ps -C etcd -o cmd --no-headers | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
       tests:
         test_items:
         - flag: "700"
@@ -663,7 +661,7 @@ groups:
   checks:
     - id: 1.5.1
       text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--cert-file"
@@ -675,7 +673,7 @@ groups:
 
     - id: 1.5.2
       text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--client-cert-auth"
@@ -691,7 +689,7 @@ groups:
 
     - id: 1.5.3
       text: "Ensure that the --auto-tls argument is not set to true (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         bin_op: or
         test_items:
@@ -709,7 +707,7 @@ groups:
 
     - id: 1.5.4
       text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--peer-cert-file"
@@ -724,7 +722,7 @@ groups:
 
     - id: 1.5.5
       text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--peer-client-cert-auth"
@@ -742,7 +740,7 @@ groups:
 
     - id: 1.5.6
       text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         bin_op: or
         test_items:
@@ -763,7 +761,7 @@ groups:
 
     - id: 1.5.7
       text: "Ensure that the --wal-dir argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--wal-dir"
@@ -776,7 +774,7 @@ groups:
 
     - id: 1.5.8
       text: "Ensure that the --max-wals argument is set to 0 (Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--max-wals"
@@ -792,7 +790,7 @@ groups:
 
     - id: 1.5.9
       text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
-      audit: "ps -ef | grep etcd | grep -v grep"
+      audit: "ps -C etcd -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--trusted-ca-file"

--- a/cfg/node.yaml
+++ b/cfg/node.yaml
@@ -9,7 +9,7 @@ groups:
   checks:
     - id: 2.1.1
       text: "Ensure that the --allow-privileged argument is set to false (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--allow-privileged"
@@ -23,7 +23,7 @@ groups:
 
     - id: 2.1.2
       text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--anonymous-auth"
@@ -37,7 +37,7 @@ groups:
  
     - id: 2.1.3
       text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--authorization-mode"
@@ -51,7 +51,7 @@ groups:
    
     - id: 2.1.4
       text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--client-ca-file"
@@ -63,7 +63,7 @@ groups:
 
     - id: 2.1.5
       text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--read-only-port"
@@ -77,7 +77,7 @@ groups:
  
     - id: 2.1.6
       text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--streaming-connection-idle-timeout"
@@ -91,7 +91,7 @@ groups:
 
     - id: 2.1.7
       text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--protect-kernel-defaults"
@@ -105,7 +105,7 @@ groups:
 
     - id: 2.1.8
       text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         bin_op: or
         test_items:
@@ -122,7 +122,7 @@ groups:
 
     - id: 2.1.9
       text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--keep-terminated-pod-volumes"
@@ -136,7 +136,7 @@ groups:
 
     - id: 2.1.10
       text: "Ensure that the --hostname-override argument is not set (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--hostname-override"
@@ -147,7 +147,7 @@ groups:
 
     - id: 2.1.11
       text: "Ensure that the --event-qps argument is set to 0 (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--event-qps"
@@ -161,7 +161,7 @@ groups:
 
     - id: 2.1.12
       text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--tls-cert-file"
@@ -176,7 +176,7 @@ groups:
 
     - id: 2.1.13
       text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
-      audit: "ps -ef | grep kubelet | grep -v grep"
+      audit: "ps -C kubelet -o cmd --no-headers"
       tests:
         test_items:
           - flag: "--cadvisor-port"

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/aquasecurity/kube-bench/check"
@@ -29,16 +28,16 @@ import (
 
 var (
 	kubeMasterBin  = []string{"kube-apiserver", "kube-scheduler", "kube-controller-manager"}
+	xMasterBin     = []string{"etcd", "flanneld"}
 	kubeMasterConf = []string{}
 
 	kubeNodeBin  = []string{"kubelet"}
 	kubeNodeConf = []string{}
 
-	kubeFederatedBin  = []string{"federation-apiserver", "federation-controller-manager"}
-	kubeFederatedConf = []string{}
+	kubeFederatedBin = []string{"federation-apiserver", "federation-controller-manager"}
 
 	// TODO: Consider specifying this in config file.
-	kubeVersion = "Kubernetes v1.6"
+	kubeVersion = "1.6"
 
 	// Used for variable substitution
 	symbols = map[string]string{}
@@ -54,26 +53,15 @@ var (
 
 func runChecks(t check.NodeType) {
 	var summary check.Summary
-	var warnings []string
 	var file string
 
-	// Set up for config file check.
-	kubeMasterConf = append(kubeMasterConf, viper.Get("kubeConfDir").(string)+"/apiserver")
-	kubeMasterConf = append(kubeMasterConf, viper.Get("kubeConfDir").(string)+"/scheduler")
-	kubeMasterConf = append(kubeMasterConf, viper.Get("kubeConfDir").(string)+"/controller-manager")
-	kubeMasterConf = append(kubeMasterConf, viper.Get("kubeConfDir").(string)+"/config")
-	kubeMasterConf = append(kubeMasterConf, viper.Get("etcdConfDir").(string)+"/etcd.conf")
-	kubeMasterConf = append(kubeMasterConf, viper.Get("flanneldConfDir").(string)+"/flanneld")
-	kubeNodeConf = append(kubeNodeConf, viper.Get("kubeConfDir").(string)+"/kubelet")
-	kubeNodeConf = append(kubeNodeConf, viper.Get("kubeConfDir").(string)+"/proxy")
-
-	warnings, err := verifyNodeType(t, warnings)
-	if err != nil {
-		for _, w := range warnings {
-			colorPrint(check.WARN, w)
+	fails := verifyNodeType(t)
+	if len(fails) > 0 {
+		fmt.Fprintf(os.Stderr, "%s could not start: please resolve these issues\n", os.Args[0])
+		for _, w := range fails {
+			colorPrint(check.FAIL, w)
 		}
 
-		fmt.Fprintf(os.Stderr, "failed to verify node type: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -129,7 +117,7 @@ func runChecks(t check.NodeType) {
 
 		fmt.Println(string(out))
 	} else {
-		prettyPrint(warnings, controls, summary)
+		prettyPrint(fails, controls, summary)
 	}
 }
 
@@ -144,81 +132,42 @@ func cleanIDs(list string) []string {
 	return ids
 }
 
-// verifyNodeType checks the executables and config files are as expected for the specified tests (master, node or federated)
-func verifyNodeType(t check.NodeType, w []string) ([]string, error) {
-	var binPath []string
-	var confPath []string
-	var out []byte
+// verifyNodeType checks the executables and config files are as expected
+// for the specified tests (master, node or federated).
+// Any check failing here is a show stopper.
+func verifyNodeType(t check.NodeType) []string {
+	var w []string
+
+	// Set up and check for config files.
+	kubeConfDir = viper.Get("kubeConfDir").(string)
+	etcdConfDir = viper.Get("etcdConfDir").(string)
+	flanneldConfDir = viper.Get("flanneldConfDir").(string)
+
+	kubeMasterConf = append(kubeMasterConf, kubeConfDir+"/apiserver")
+	kubeMasterConf = append(kubeMasterConf, kubeConfDir+"/scheduler")
+	kubeMasterConf = append(kubeMasterConf, kubeConfDir+"/controller-manager")
+	kubeMasterConf = append(kubeMasterConf, kubeConfDir+"/config")
+	kubeMasterConf = append(kubeMasterConf, etcdConfDir+"/etcd.conf")
+	kubeMasterConf = append(kubeMasterConf, flanneldConfDir+"/flanneld")
+
+	kubeNodeConf = append(kubeNodeConf, kubeConfDir+"/kubelet")
+	kubeNodeConf = append(kubeNodeConf, kubeConfDir+"/proxy")
+
+	w = append(w, verifyKubeVersion(kubeMasterBin)...)
 
 	switch t {
 	case check.MASTER:
-		binPath = kubeMasterBin
-		confPath = kubeMasterConf
+		w = append(w, verifyBin(kubeMasterBin)...)
+		w = append(w, verifyBin(xMasterBin)...)
+		w = append(w, verifyConf(kubeMasterConf)...)
 	case check.NODE:
-		binPath = kubeNodeBin
-		confPath = kubeNodeConf
+		w = append(w, verifyBin(kubeNodeBin)...)
+		w = append(w, verifyConf(kubeNodeConf)...)
 	case check.FEDERATED:
-		binPath = kubeFederatedBin
-		confPath = kubeFederatedConf
+		w = append(w, verifyBin(kubeFederatedBin)...)
 	}
 
-	// These executables might not be on the user's path.
-	// TODO! Check the version number using kubectl, which is more likely to be on the path.
-	for _, b := range binPath {
-		_, err := exec.LookPath(b)
-		if err != nil {
-			w = append(w, fmt.Sprintf("%s: command not found on path - version check skipped\n", b))
-			continue
-		}
-
-		// Check version
-		cmd := exec.Command(b, "--version")
-		out, err = cmd.Output()
-		if err != nil {
-			return w, fmt.Errorf("failed executing %s --version: %v", b, err)
-		}
-
-		matched, err := regexp.MatchString(kubeVersion, string(out))
-		if err != nil {
-			return w, fmt.Errorf("regexp match for version failed: %v", err)
-		}
-
-		if !matched {
-			return w, fmt.Errorf(
-				"%s unsupported version, expected %s, got %s",
-				b,
-				kubeVersion,
-				string(out),
-			)
-		}
-	}
-
-	// Check if the executables for this type of node are running.
-	for _, b := range binPath {
-		cmd := exec.Command("ps", "-ef")
-		out, err := cmd.Output()
-		if err != nil {
-			return w, fmt.Errorf("failed executing ps -ef: %v", err)
-		}
-
-		matched, err := regexp.MatchString(".*"+b, string(out))
-		if err != nil {
-			return w, fmt.Errorf("regexp match for ps output failed: %v", err)
-		}
-
-		if !matched {
-			return w, fmt.Errorf("%s is not running", b)
-		}
-	}
-
-	// Check whether the config files for this type of node are in the expected location
-	for _, c := range confPath {
-		if _, err := os.Stat(c); os.IsNotExist(err) {
-			w = append(w, fmt.Sprintf("config file %s does not exist\n", c))
-		}
-	}
-
-	return w, nil
+	return w
 }
 
 // colorPrint outputs the state in a specific colour, along with a message string
@@ -272,4 +221,77 @@ func prettyPrint(warnings []string, r *check.Controls, summary check.Summary) {
 	fmt.Printf("%d checks PASS\n%d checks FAIL\n%d checks WARN\n",
 		summary.Pass, summary.Fail, summary.Warn,
 	)
+}
+
+func verifyConf(confPath []string) []string {
+	var w []string
+	for _, c := range confPath {
+		if _, err := os.Stat(c); err != nil && os.IsNotExist(err) {
+			w = append(w, fmt.Sprintf("config file %s does not exist\n", c))
+		}
+	}
+
+	return w
+}
+
+func verifyBin(binPath []string) []string {
+	var w []string
+	var binList string
+
+	// Construct proc name for ps(1)
+	for _, b := range binPath {
+		binList += b + ","
+	}
+	binList = strings.Trim(binList, ",")
+
+	// Run ps command
+	cmd := exec.Command("ps", "-C", binList, "-o", "cmd", "--no-headers")
+	out, err := cmd.Output()
+	if err != nil {
+		w = append(w, fmt.Sprintf("%v could not get process information\n", binPath))
+	}
+
+	// Actual verification
+	for _, b := range binPath {
+		matched := strings.Contains(string(out), b)
+
+		if !matched {
+			w = append(w, fmt.Sprintf("%s is not running\n", b))
+		}
+	}
+
+	return w
+}
+
+func verifyKubeVersion(binPath []string) []string {
+	// These executables might not be on the user's path.
+	// TODO! Check the version number using kubectl, which is more likely to be on the path.
+	var w []string
+
+	for _, b := range binPath {
+		_, err := exec.LookPath(b)
+		if err != nil {
+			w = append(w, fmt.Sprintf("%s: command not found on path - version check skipped\n", b))
+			continue
+		}
+
+		// Check version
+		cmd := exec.Command(b, "--version")
+		out, err := cmd.Output()
+		if err != nil {
+			w = append(w, fmt.Sprintf("failed executing %s --version: %v\n", b, err))
+		}
+
+		matched := strings.Contains(string(out), kubeVersion)
+		if !matched {
+			w = append(w, fmt.Sprintf(
+				"%s unsupported version, expected %s, got %s\n",
+				b,
+				kubeVersion,
+				string(out),
+			))
+		}
+	}
+
+	return w
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,9 +34,9 @@ var (
 	nodeFile      string
 	federatedFile string
 
-	kubeConfDir    string
-	etcdConfDir    string
-	flannelConfDir string
+	kubeConfDir     string
+	etcdConfDir     string
+	flanneldConfDir string
 )
 
 // RootCmd represents the base command when called without any subcommands


### PR DESCRIPTION
This is caused by a command in the audit pipeline (for example
ps -ef | grep kube-apiserver) failing. The causes of this failure
in my testing is usually a missing config file.

Extensive refactor and correction in verification code to check for
config files and binaries.

Replace joncalhoun/pipes with implementation using exec.Cmds so errors
are visible and can be handled when audit pipeline commands fail.

Change some audit commands
from: ps -ef | grep <cmd> | grep -v
to:   ps -C <something> -o comm,args --no-headers

which is simpler to work with.