### PR TITLE
Change node check 2.1.6 to use operation `noteq` instead of `gt`.

### DIFF
--- a/cfg/node.yaml
+++ b/cfg/node.yaml
@@ -79,10 +79,11 @@ groups:
       text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
       audit: "ps -ef | grep $kubeletbin | grep -v grep"
       tests:
+        bin_op: or
         test_items:
           - flag: "--streaming-connection-idle-timeout"
             compare:
-              op: gt
+              op: noteq
               value: 0
             set: true
       remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 


### PR DESCRIPTION
Kubelet option --streaming-connection-idle-timeout expects a string
value which fails parsing to integer for greater than comparison.

The string "0" indicates no timeout and this is what we are checking
for.