### PR TITLE
Auto-detect executables and config files 

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -7,106 +7,70 @@
 # nodeControls: ./cfg/node.yaml
 # federatedControls: ./cfg/federated.yaml
 
-## Support components
-etcd:
-  bin: etcd
-  conf: /etc/etcd/etcd.conf
+master:
+  bins: 
+    apiserver:
+      - "kube-apiserver"
+      - "hyperkube apiserver"
+      - "apiserver"
+    scheduler:
+      - "kube-scheduler"
+      - "hyperkube scheduler"
+      - "scheduler"
+    controllermanager:
+      - "kube-controller-manager"
+      - "hyperkube controller-manager"
+      - "controller-manager"
+  confs:
+    apiserver: 
+      - /etc/kubernetes/admin.conf
+      - /etc/kubernetes/apiserver
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+    scheduler: 
+      - /etc/kubernetes/scheduler.conf
+      - /etc/kubernetes/scheduler
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+    controller-manager: 
+      - /etc/kubernetes/controller-manager.conf
+      - /etc/kubernetes/controller-manager
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
+    etcd:
+      - /etc/etcd/etcd.conf
+    flanneld:
+      - /etc/sysconfig/flanneld
 
-flanneld:
-  bin: flanneld
-  conf: /etc/sysconfig/flanneld
+node:
+  bins:
+    kubelet:
+      - "hyperkube kubelet"
+      - "kubelet"
+    proxy:
+      - "kube-proxy"
+      - "hyperkube proxy"
+      - "proxy"
+  confs:
+    kubelet: 
+      - /etc/kubernetes/kubelet.conf
+      - /etc/kubernetes/kubelet
+    proxy: 
+      - /etc/kubernetes/proxy.conf
+      - /etc/kubernetes/proxy
+      - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
 
-# Installation
-# Configure kubernetes component binaries and paths to their configuration files.
-installation:
-  default:
-    config: /etc/kubernetes/config
-    master:
-      bin:
-        apiserver: apiserver
-        scheduler: scheduler
-        controller-manager: controller-manager
-      conf:
-        apiserver: /etc/kubernetes/apiserver
-        scheduler: /etc/kubernetes/scheduler
-        controller-manager: /etc/kubernetes/controller-manager
-    node:
-      bin:
-        kubelet: kubelet
-        proxy: proxy
-      conf:
-        kubelet: /etc/kubernetes/kubelet
-        proxy: /etc/kubernetes/proxy
-    federated:
-      bin:
-        apiserver: federation-apiserver
-        controller-manager: federation-controller-manager
+federated:
+  bins:
+    fedapiserver:
+      - "hyperkube federation-apiserver"
+      - "kube-federation-apiserver"
+      - "federation-apiserver"
+    fedcontrollermanager:
+      - "hyperkube federation-controller-manager"
+      - "kube-federation-controller-manager"
+      - "federation-controller-manager"
 
-  kops:
-    config: /etc/kubernetes/config
-    master:
-      bin:
-        apiserver: apiserver
-        scheduler: scheduler
-        controller-manager: controller-manager
-      conf:
-        apiserver: /etc/kubernetes/apiserver
-        scheduler: /etc/kubernetes/scheduler
-        controller-manager: /etc/kubernetes/apiserver
-    node:
-      bin:
-        kubelet: kubelet
-        proxy: proxy
-      conf:
-        kubelet: /etc/kubernetes/kubelet
-        proxy: /etc/kubernetes/proxy
-    federated:
-      bin:
-        apiserver: federation-apiserver
-        controller-manager: federation-controller-manager
-
-  hyperkube:
-    config: /etc/kubernetes/config
-    master:
-      bin:
-        apiserver: hyperkube apiserver
-        scheduler: hyperkube scheduler
-        controller-manager: hyperkube controller-manager
-      conf:
-        apiserver: /etc/kubernetes/manifests/kube-apiserver.yaml
-        scheduler: /etc/kubernetes/manifests/kube-scheduler.yaml
-        controller-manager: /etc/kubernetes/manifests/kube-controller-manager.yaml
-    node:
-      bin:
-        kubelet: hyperkube kubelet
-        proxy: hyperkube proxy
-      conf:
-        kubelet: /etc/kubernetes/kubelet
-        proxy: /etc/kubernetes/addons/kube-proxy-daemonset.yaml
-    federated:
-      bin:
-        apiserver: hyperkube federation-apiserver
-        controller-manager: hyperkube federation-controller-manager
-
-  kubeadm:
-    config: /etc/kubernetes/config
-    master:
-      bin:
-        apiserver: kube-apiserver
-        scheduler: kube-scheduler
-        controller-manager: kube-controller-manager
-      conf:
-        apiserver: /etc/kubernetes/admin.conf
-        scheduler: /etc/kubernetes/scheduler.conf
-        controller-manager: /etc/kubernetes/controller-manager.conf
-    node:
-      bin:
-        kubelet: kubelet
-        proxy: kube-proxy
-      conf:
-        kubelet: /etc/kubernetes/kubelet.conf
-        proxy: /etc/kubernetes/proxy.conf
-    federated:
-      bin:
-        apiserver: kube-federation-apiserver
-        controller-manager: kube-federation-controller-manager
+optional:
+  bins:
+    etcd:
+      - "etcd"
+    flanneld:
+      - "flanneld"

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -8,69 +8,106 @@
 # federatedControls: ./cfg/federated.yaml
 
 master:
-  bins: 
-    apiserver:
+  components:
+    - apiserver
+    - scheduler
+    - controllermanager
+    - etcd 
+    - flanneld
+    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the 
+    # benchmark but is believed to now be obselete
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config
+
+  apiserver:
+    bins:
       - "kube-apiserver"
       - "hyperkube apiserver"
       - "apiserver"
-    scheduler:
+    confs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/apiserver.conf
+      - /etc/kubernetes/apiserver
+    defaultconf: /etc/kubernetes/apiserver
+
+  scheduler:
+    bins:
       - "kube-scheduler"
       - "hyperkube scheduler"
       - "scheduler"
-    controllermanager:
+    confs: 
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/scheduler.conf
+      - /etc/kubernetes/scheduler
+    defaultconf: /etc/kubernetes/scheduler
+
+  controllermanager:
+    bins:
       - "kube-controller-manager"
       - "hyperkube controller-manager"
       - "controller-manager"
-  confs:
-    apiserver: 
-      - /etc/kubernetes/admin.conf
-      - /etc/kubernetes/apiserver
-      - /etc/kubernetes/manifests/kube-apiserver.yaml
-    scheduler: 
-      - /etc/kubernetes/scheduler.conf
-      - /etc/kubernetes/scheduler
-      - /etc/kubernetes/manifests/kube-scheduler.yaml
-    controller-manager: 
+    confs:
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
       - /etc/kubernetes/controller-manager.conf
       - /etc/kubernetes/controller-manager
-      - /etc/kubernetes/manifests/kube-controller-manager.yaml
-    etcd:
+    defaultconf: /etc/kubernetes/controller-manager
+
+  etcd:
+    optional: true
+    bins:
+      - "etcd"
+    confs:
+      - /etc/kubernetes/manifests/etcd.yaml
       - /etc/etcd/etcd.conf
-    flanneld:
-      - /etc/sysconfig/flanneld
+    defaultconf: /etc/etcd/etcd.conf
+
+  flanneld:
+    optional: true
+    bins:
+      - flanneld
+    defaultconf: /etc/sysconfig/flanneld
+
 
 node:
-  bins:
-    kubelet:
+  components:
+    - kubelet
+    - proxy
+
+  kubelet:
+    bins:
       - "hyperkube kubelet"
       - "kubelet"
-    proxy:
+    confs:
+      - /etc/kubernetes/kubelet.conf
+      - /etc/kubernetes/kubelet
+  
+  proxy:
+    bins:
       - "kube-proxy"
       - "hyperkube proxy"
       - "proxy"
-  confs:
-    kubelet: 
-      - /etc/kubernetes/kubelet.conf
-      - /etc/kubernetes/kubelet
-    proxy: 
+    confs:
       - /etc/kubernetes/proxy.conf
       - /etc/kubernetes/proxy
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
 
 federated:
-  bins:
-    fedapiserver:
+  components:
+    - fedapiserver
+    - fedcontrollermanager
+
+  fedapiserver:
+    bins:
       - "hyperkube federation-apiserver"
       - "kube-federation-apiserver"
       - "federation-apiserver"
-    fedcontrollermanager:
+
+  fedcontrollermanager:
+    bins:
       - "hyperkube federation-controller-manager"
       - "kube-federation-controller-manager"
       - "federation-controller-manager"
 
-optional:
-  bins:
-    etcd:
-      - "etcd"
-    flanneld:
-      - "flanneld"
+

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -14,8 +14,7 @@ master:
     - controllermanager
     - etcd 
     - flanneld
-    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the 
-    # benchmark but is believed to now be obselete
+    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
     - kubernetes
 
   kubernetes:
@@ -74,6 +73,11 @@ node:
   components:
     - kubelet
     - proxy
+    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config    
 
   kubelet:
     bins:
@@ -81,7 +85,8 @@ node:
       - "kubelet"
     confs:
       - /etc/kubernetes/kubelet.conf
-      - /etc/kubernetes/kubelet
+      - /etc/kubernetes/kubelet 
+    defaultconf: "/etc/kubernetes/kubelet.conf"
   
   proxy:
     bins:

--- a/cfg/master.yaml
+++ b/cfg/master.yaml
@@ -636,7 +636,7 @@ groups:
 
     - id: 1.4.3
       text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $config; then stat -c %a $config; fi'"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %a $kubernetesconf; fi'"
       tests:
         bin_op: or
         test_items:
@@ -656,12 +656,12 @@ groups:
             value: "600"
           set: true
       remediation: "Run the below command (based on the file location on your system) on the master node. 
-              \nFor example, chmod 644 $config"
+              \nFor example, chmod 644 $kubernetesconf"
       scored: true
 
     - id: 1.4.4
       text: "Ensure that the config file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $config; then stat -c %U:%G $config; fi'"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %U:%G $kubernetesconf; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -670,7 +670,7 @@ groups:
             value: "root:root"
           set: true
       remediation: "Run the below command (based on the file location on your system) on the master node. 
-              \nFor example, chown root:root $config"
+              \nFor example, chown root:root $kubernetesconf"
       scored: true
 
     - id: 1.4.5

--- a/cfg/node.yaml
+++ b/cfg/node.yaml
@@ -17,7 +17,7 @@ groups:
               op: eq
               value: false
             set: true
-      remediation: "Edit the $config file on each node and set the KUBE_ALLOW_PRIV 
+      remediation: "Edit the $kubeletconf file on each node and set the KUBE_ALLOW_PRIV 
               parameter to \"--allow-privileged=false\""
       scored: true
 
@@ -199,7 +199,7 @@ groups:
               op: eq
               value: true
             set: true
-      remediation: "Edit the /etc/kubernetes/kubelet file on each node and set the KUBELET_ARGS parameter
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter
               to a value to include \"--feature-gates=RotateKubeletClientCertificate=true\"."
       scored: true
 
@@ -213,7 +213,7 @@ groups:
               op: eq
               value: true
             set: true
-      remediation: "Edit the /etc/kubernetes/kubelet file on each node and set the KUBELET_ARGS parameter
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter
               to a value to include \"--feature-gates=RotateKubeletServerCertificate=true\"."
       scored: true
 
@@ -222,7 +222,7 @@ groups:
   checks:
     - id: 2.2.1
       text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $config; then stat -c %a $config; fi'"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %a $kubernetesconf; fi'"
       tests:
         bin_op: or
         test_items:
@@ -242,12 +242,12 @@ groups:
               value: "600"
             set: true
       remediation: "Run the below command (based on the file location on your system) on the each worker node. 
-              \nFor example, chmod 644 $config"
+              \nFor example, chmod 644 $kubernetesconf"
       scored: true
 
     - id: 2.2.2
       text: "Ensure that the config file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $config; then stat -c %U:%G $config; fi'"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %U:%G $kubernetesconf; fi'"
       tests:
         test_items:
           - flag: "root:root"
@@ -256,7 +256,7 @@ groups:
               value: root:root
             set: true
       remediation: "Run the below command (based on the file location on your system) on the each worker node. 
-              \nFor example, chown root:root $config"
+              \nFor example, chown root:root $kubernetesconf"
       scored: true
 
     - id: 2.2.3

--- a/check/check.go
+++ b/check/check.go
@@ -156,7 +156,9 @@ func (c *Check) Run() {
 		i++
 	}
 
-	glog.V(2).Info("%s\n", errmsgs)
+	if errmsgs != "" {
+		glog.V(2).Info(errmsgs)
+	}
 
 	res := c.Tests.execute(out.String())
 	if res {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -74,7 +74,6 @@ func runChecks(t check.NodeType) {
 
 	// Run kubernetes installation validation checks.
 	verifyKubeVersion(kubeMajorVersion, kubeMinorVersion)
-	verifyNodeType(t)
 
 	switch t {
 	case check.MASTER:
@@ -123,41 +122,6 @@ func runChecks(t check.NodeType) {
 		fmt.Println(string(out))
 	} else {
 		prettyPrint(controls, summary)
-	}
-}
-
-// verifyNodeType checks the executables and config files are as expected
-// for the specified tests (master, node or federated).
-func verifyNodeType(t check.NodeType) {
-	var bins []string
-	var confs []string
-
-	switch t {
-	case check.MASTER:
-		bins = []string{apiserverBin, schedulerBin, controllerManagerBin}
-		confs = []string{apiserverConf, schedulerConf, controllerManagerConf}
-	case check.NODE:
-		bins = []string{kubeletBin, proxyBin}
-		confs = []string{kubeletConf, proxyConf}
-	case check.FEDERATED:
-		bins = []string{fedApiserverBin, fedControllerManagerBin}
-	}
-
-	for _, bin := range bins {
-		if !verifyBin(bin) {
-			printlnWarn(fmt.Sprintf("%s is not running", bin))
-		}
-	}
-
-	for _, conf := range confs {
-		_, err := os.Stat(conf)
-		if err != nil {
-			if os.IsNotExist(err) {
-				printlnWarn(fmt.Sprintf("Missing kubernetes config file: %s", conf))
-			} else {
-				exitWithError(fmt.Errorf("error looking for file %s: %v", conf, err))
-			}
-		}
 	}
 }
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/viper"
@@ -67,10 +66,10 @@ func runChecks(t check.NodeType) {
 		typeConf = viper.Sub("federated")
 	}
 
-	// Get the set of exectuables we care about on this type of node
-	binmap := getBinaries(typeConf.Sub("bins"), false)
-	extrasmap := getBinaries(viper.Sub("optional"), true)
-	confmap := getConfigFiles(typeConf.Sub("confs"))
+	// Get the set of exectuables and config files we care about on this type of node. This also
+	// checks that the executables we need for the node type are running.
+	binmap := getBinaries(typeConf)
+	confmap := getConfigFiles(typeConf)
 
 	// Run kubernetes installation validation checks.
 	verifyKubeVersion(kubeMajorVersion, kubeMinorVersion)
@@ -92,7 +91,6 @@ func runChecks(t check.NodeType) {
 	// Variable substitutions. Replace all occurrences of variables in controls files.
 	s := string(in)
 	s = makeSubstitutions(s, "bin", binmap)
-	s = makeSubstitutions(s, "bin", extrasmap)
 	s = makeSubstitutions(s, "conf", confmap)
 
 	controls, err := check.NewControls(t, []byte(s))

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 
 	"github.com/aquasecurity/kube-bench/check"
+	"github.com/golang/glog"
 	"github.com/spf13/viper"
 )
 
@@ -53,6 +54,8 @@ func runChecks(t check.NodeType) {
 	var file string
 	var err error
 	var typeConf *viper.Viper
+
+	glog.V(1).Info(fmt.Sprintf("Using config file: %s\n", viper.ConfigFileUsed()))
 
 	switch t {
 	case check.MASTER:
@@ -131,8 +134,6 @@ func colorPrint(state check.State, s string) {
 
 // prettyPrint outputs the results to stdout in human-readable format
 func prettyPrint(r *check.Controls, summary check.Summary) {
-	colorPrint(check.INFO, fmt.Sprintf("Using config file: %s\n", viper.ConfigFileUsed()))
-
 	colorPrint(check.INFO, fmt.Sprintf("%s %s\n", r.ID, r.Text))
 	for _, g := range r.Groups {
 		colorPrint(check.INFO, fmt.Sprintf("%s %s\n", g.ID, g.Text))

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -165,7 +165,7 @@ func verifyNodeType(t check.NodeType) {
 	}
 
 	for _, bin := range bins {
-		if !verifyBin(bin, ps) {
+		if !verifyBin(bin) {
 			printlnWarn(fmt.Sprintf("%s is not running", bin))
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,14 +34,6 @@ var (
 	masterFile    string
 	nodeFile      string
 	federatedFile string
-
-	loud bool
-
-	kubeConfDir     string
-	etcdConfDir     string
-	flanneldConfDir string
-
-	installation string
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -67,12 +59,6 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
-	RootCmd.PersistentFlags().StringVar(
-		&installation,
-		"installation",
-		"default",
-		"Specify how kubernetes cluster was installed. Possible values are default,hyperkube,kops,kubeadm",
-	)
 	RootCmd.PersistentFlags().StringVarP(
 		&checkList,
 		"check",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -87,7 +87,19 @@ func verifyBin(bin string, psFunc func(string) string) bool {
 	proc := strings.Fields(bin)[0]
 	out := psFunc(proc)
 
-	return strings.Contains(out, bin)
+	if !strings.Contains(out, bin) {
+		return false
+	}
+
+	// Make sure we're not just matching on a partial word (e.g. if we're looking for apiserver, don't match on kube-apiserver)
+	// This will give a false positive for matching "one two" against "zero one two-x" but it will do for now
+	for _, f := range strings.Fields(out) {
+		if f == proc {
+			return true
+		}
+	}
+
+	return false
 }
 
 // findExecutable looks through a list of possible executable names and finds the first one that's running

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -22,6 +22,14 @@ var (
 	}
 )
 
+var psFunc func(string) string
+var statFunc func(string) (os.FileInfo, error)
+
+func init() {
+	psFunc = ps
+	statFunc = os.Stat
+}
+
 func printlnWarn(msg string) {
 	fmt.Fprintf(os.Stderr, "[%s] %s\n",
 		colors[check.WARN].Sprintf("%s", check.WARN),
@@ -76,7 +84,7 @@ func ps(proc string) string {
 }
 
 // verifyBin checks that the binary specified is running
-func verifyBin(bin string, psFunc func(string) string) bool {
+func verifyBin(bin string) bool {
 
 	// Strip any quotes
 	bin = strings.Trim(bin, "'\"")
@@ -103,9 +111,9 @@ func verifyBin(bin string, psFunc func(string) string) bool {
 }
 
 // findExecutable looks through a list of possible executable names and finds the first one that's running
-func findExecutable(candidates []string, psFunc func(string) string) (string, error) {
+func findExecutable(candidates []string) (string, error) {
 	for _, c := range candidates {
-		if verifyBin(c, psFunc) {
+		if verifyBin(c) {
 			return c, nil
 		}
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -90,6 +90,17 @@ func verifyBin(bin string, psFunc func(string) string) bool {
 	return strings.Contains(out, bin)
 }
 
+// findExecutable looks through a list of possible executable names and finds the first one that's running
+func findExecutable(candidates []string, psFunc func(string) string) (string, error) {
+	for _, c := range candidates {
+		if verifyBin(c, psFunc) {
+			return c, nil
+		}
+	}
+
+	return "", fmt.Errorf("no candidates running")
+}
+
 func verifyKubeVersion(major string, minor string) {
 	// These executables might not be on the user's path.
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -243,6 +243,10 @@ func multiWordReplace(s string, subname string, sub string) string {
 func makeSubstitutions(s string, ext string, m map[string]string) string {
 	for k, v := range m {
 		subst := "$" + k + ext
+		if v == "" {
+			glog.V(2).Info(fmt.Sprintf("No subsitution for '%s'\n", subst))
+			continue
+		}
 		glog.V(1).Info(fmt.Sprintf("Substituting %s with '%s'\n", subst, v))
 		s = multiWordReplace(s, subst, v)
 	}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -97,10 +97,11 @@ func TestVerifyBin(t *testing.T) {
 		{proc: "cmd param", psOut: "cmd", exp: false},
 	}
 
+	psFunc = fakeps
 	for id, c := range cases {
 		t.Run(strconv.Itoa(id), func(t *testing.T) {
 			g = c.psOut
-			v := verifyBin(c.proc, fakeps)
+			v := verifyBin(c.proc)
 			if v != c.exp {
 				t.Fatalf("Expected %v got %v", c.exp, v)
 			}
@@ -120,12 +121,15 @@ func TestFindExecutable(t *testing.T) {
 		{candidates: []string{"one double", "two double", "three double"}, psOut: "two double is running", exp: "two double"},
 		{candidates: []string{"one", "two", "three"}, psOut: "blah", expErr: true},
 		{candidates: []string{"one double", "two double", "three double"}, psOut: "two", expErr: true},
+		{candidates: []string{"apiserver", "kube-apiserver"}, psOut: "kube-apiserver", exp: "kube-apiserver"},
+		{candidates: []string{"apiserver", "kube-apiserver", "hyperkube-apiserver"}, psOut: "kube-apiserver", exp: "kube-apiserver"},
 	}
 
+	psFunc = fakeps
 	for id, c := range cases {
 		t.Run(strconv.Itoa(id), func(t *testing.T) {
 			g = c.psOut
-			e, err := findExecutable(c.candidates, fakeps)
+			e, err := findExecutable(c.candidates)
 			if e != c.exp {
 				t.Fatalf("Expected %v got %v", c.exp, e)
 			}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -108,6 +108,11 @@ func TestVerifyBin(t *testing.T) {
 		{proc: "cmd", psOut: "cmd param1 param2", exp: true},
 		{proc: "cmd param", psOut: "cmd param1 param2", exp: true},
 		{proc: "cmd param", psOut: "cmd", exp: false},
+		{proc: "cmd", psOut: "cmd x \ncmd y", exp: true},
+		{proc: "cmd y", psOut: "cmd x \ncmd y", exp: true},
+		{proc: "cmd", psOut: "/usr/bin/cmd", exp: true},
+		{proc: "cmd", psOut: "kube-cmd", exp: false},
+		{proc: "cmd", psOut: "/usr/bin/kube-cmd", exp: false},
 	}
 
 	psFunc = fakeps

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -108,6 +108,39 @@ func TestVerifyBin(t *testing.T) {
 	}
 }
 
+func TestFindExecutable(t *testing.T) {
+	cases := []struct {
+		candidates []string // list of executables we'd consider
+		psOut      string   // fake output from ps
+		exp        string   // the one we expect to find in the (fake) ps output
+		expErr     bool
+	}{
+		{candidates: []string{"one", "two", "three"}, psOut: "two", exp: "two"},
+		{candidates: []string{"one", "two", "three"}, psOut: "two three", exp: "two"},
+		{candidates: []string{"one double", "two double", "three double"}, psOut: "two double is running", exp: "two double"},
+		{candidates: []string{"one", "two", "three"}, psOut: "blah", expErr: true},
+		{candidates: []string{"one double", "two double", "three double"}, psOut: "two", expErr: true},
+	}
+
+	for id, c := range cases {
+		t.Run(strconv.Itoa(id), func(t *testing.T) {
+			g = c.psOut
+			e, err := findExecutable(c.candidates, fakeps)
+			if e != c.exp {
+				t.Fatalf("Expected %v got %v", c.exp, e)
+			}
+
+			if err == nil && c.expErr {
+				t.Fatalf("Expected error")
+			}
+
+			if err != nil && !c.expErr {
+				t.Fatalf("Didn't expect error: %v", err)
+			}
+		})
+	}
+}
+
 func TestMultiWordReplace(t *testing.T) {
 	cases := []struct {
 		input   string

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -189,13 +189,13 @@ func TestGetBinaries(t *testing.T) {
 		{
 			// more than one component
 			config: map[string]interface{}{"components": []string{"apiserver", "thing"}, "apiserver": map[string]interface{}{"bins": []string{"apiserver", "kube-apiserver"}}, "thing": map[string]interface{}{"bins": []string{"something else", "thing"}}},
-			psOut:  "kube-apiserver thing",
+			psOut:  "kube-apiserver \nthing",
 			exp:    map[string]string{"apiserver": "kube-apiserver", "thing": "thing"},
 		},
 		{
 			// default binary to component name
 			config: map[string]interface{}{"components": []string{"apiserver", "thing"}, "apiserver": map[string]interface{}{"bins": []string{"apiserver", "kube-apiserver"}}, "thing": map[string]interface{}{"bins": []string{"something else", "thing"}, "optional": true}},
-			psOut:  "kube-apiserver otherthing",
+			psOut:  "kube-apiserver \notherthing some params",
 			exp:    map[string]string{"apiserver": "kube-apiserver", "thing": "thing"},
 		},
 	}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -185,7 +185,7 @@ func TestGetBinaries(t *testing.T) {
 			for k, val := range c.config {
 				v.Set(k, val)
 			}
-			m := getBinaries(v)
+			m := getBinaries(v, false)
 			if !reflect.DeepEqual(m, c.exp) {
 				t.Fatalf("Got %v\nExpected %v", m, c.exp)
 			}
@@ -271,6 +271,26 @@ func TestGetConfigFiles(t *testing.T) {
 			m := getConfigFiles(v)
 			if !reflect.DeepEqual(m, c.exp) {
 				t.Fatalf("Got %v\nExpected %v", m, c.exp)
+			}
+		})
+	}
+}
+
+func TestMakeSubsitutions(t *testing.T) {
+	cases := []struct {
+		input string
+		subst map[string]string
+		exp   string
+	}{
+		{input: "Replace $thisbin", subst: map[string]string{"this": "that"}, exp: "Replace that"},
+		{input: "Replace $thisbin", subst: map[string]string{"this": "that", "here": "there"}, exp: "Replace that"},
+		{input: "Replace $thisbin and $herebin", subst: map[string]string{"this": "that", "here": "there"}, exp: "Replace that and there"},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			s := makeSubstitutions(c.input, "bin", c.subst)
+			if s != c.exp {
+				t.Fatalf("Got %s expected %s", s, c.exp)
 			}
 		})
 	}


### PR DESCRIPTION
In this PR I've restructured the YAML. Each component has a set of possible binaries and config files, and we look through them to see which one is in use on the system. We then substitute the binaries and config file names into the tests. 

This means we don't need the --installation flag any more. If we learn about other executables or config file locations we can simply add them to the config.yaml file. 