### PR TITLE
Client server error message on 1.6

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -43,10 +43,6 @@ var (
 	fedControllerManagerBin string
 
 	errmsgs string
-
-	// TODO: Consider specifying this in config file.
-	kubeMajorVersion = "1"
-	kubeMinorVersion = "7"
 )
 
 func runChecks(t check.NodeType) {
@@ -73,9 +69,6 @@ func runChecks(t check.NodeType) {
 	// checks that the executables we need for the node type are running.
 	binmap := getBinaries(typeConf)
 	confmap := getConfigFiles(typeConf)
-
-	// Run kubernetes installation validation checks.
-	verifyKubeVersion(kubeMajorVersion, kubeMinorVersion)
 
 	switch t {
 	case check.MASTER:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -51,8 +51,6 @@ func runChecks(t check.NodeType) {
 	var err error
 	var typeConf *viper.Viper
 
-	glog.V(1).Info(fmt.Sprintf("Using config file: %s\n", viper.ConfigFileUsed()))
-
 	switch t {
 	case check.MASTER:
 		file = masterFile
@@ -90,6 +88,9 @@ func runChecks(t check.NodeType) {
 	s := string(in)
 	s = makeSubstitutions(s, "bin", binmap)
 	s = makeSubstitutions(s, "conf", confmap)
+
+	glog.V(1).Info(fmt.Sprintf("Using config file: %s\n", viper.ConfigFileUsed()))
+	glog.V(1).Info(fmt.Sprintf("Using benchmark file: %s\n", path))
 
 	controls, err := check.NewControls(t, []byte(s))
 	if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -202,67 +202,6 @@ func findExecutable(candidates []string) (string, error) {
 	return "", fmt.Errorf("no candidates running")
 }
 
-func verifyKubeVersion(major string, minor string) {
-	// These executables might not be on the user's path.
-
-	_, err := exec.LookPath("kubectl")
-	if err != nil {
-		continueWithError(err, sprintlnWarn("Kubernetes version check skipped"))
-		return
-	}
-
-	cmd := exec.Command("kubectl", "version")
-	out, err := cmd.Output()
-	if err != nil {
-		s := fmt.Sprintf("Kubernetes version check skipped with error %v", err)
-		continueWithError(err, sprintlnWarn(s))
-		if len(out) == 0 {
-			return
-		}
-	}
-
-	msg := checkVersion("Client", string(out), major, minor)
-	if msg != "" {
-		continueWithError(fmt.Errorf(msg), msg)
-	}
-
-	msg = checkVersion("Server", string(out), major, minor)
-	if msg != "" {
-		continueWithError(fmt.Errorf(msg), msg)
-	}
-}
-
-var regexVersionMajor = regexp.MustCompile("Major:\"([0-9]+)\"")
-var regexVersionMinor = regexp.MustCompile("Minor:\"([0-9]+)\"")
-
-func checkVersion(x string, s string, expMajor string, expMinor string) string {
-	regexVersion, err := regexp.Compile(x + " Version: version.Info{(.*)}")
-	if err != nil {
-		return fmt.Sprintf("Error checking Kubernetes version: %v", err)
-	}
-
-	ss := regexVersion.FindString(s)
-	major := versionMatch(regexVersionMajor, ss)
-	minor := versionMatch(regexVersionMinor, ss)
-	if major == "" || minor == "" {
-		return fmt.Sprintf("Couldn't find %s version from kubectl output '%s'", x, s)
-	}
-
-	if major != expMajor || minor != expMinor {
-		return fmt.Sprintf("Unexpected %s version %s.%s", x, major, minor)
-	}
-
-	return ""
-}
-
-func versionMatch(r *regexp.Regexp, s string) string {
-	match := r.FindStringSubmatch(s)
-	if len(match) < 2 {
-		return ""
-	}
-	return match[1]
-}
-
 func multiWordReplace(s string, subname string, sub string) string {
 	f := strings.Fields(sub)
 	if len(f) > 1 {

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -24,63 +24,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func TestCheckVersion(t *testing.T) {
-	kubeoutput := `Client Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.0", GitCommit:"d3ada0119e776222f11ec7945e6d860061339aad", GitTreeState:"clean", BuildDate:"2017-06-30T09:51:01Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"darwin/amd64"}
-	Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.0", GitCommit:"d3ada0119e776222f11ec7945e6d860061339aad", GitTreeState:"clean", BuildDate:"2017-07-26T00:12:31Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}`
-	cases := []struct {
-		t     string
-		s     string
-		major string
-		minor string
-		exp   string
-	}{
-		{t: "Client", s: kubeoutput, major: "1", minor: "7"},
-		{t: "Server", s: kubeoutput, major: "1", minor: "7"},
-		{t: "Client", s: kubeoutput, major: "1", minor: "6", exp: "Unexpected Client version 1.7"},
-		{t: "Client", s: kubeoutput, major: "2", minor: "0", exp: "Unexpected Client version 1.7"},
-		{t: "Server", s: "something unexpected", major: "2", minor: "0", exp: "Couldn't find Server version from kubectl output 'something unexpected'"},
-	}
-
-	for id, c := range cases {
-		t.Run(strconv.Itoa(id), func(t *testing.T) {
-			m := checkVersion(c.t, c.s, c.major, c.minor)
-			if m != c.exp {
-				t.Fatalf("Got: %s, expected: %s", m, c.exp)
-			}
-		})
-	}
-
-}
-
-func TestVersionMatch(t *testing.T) {
-	minor := regexVersionMinor
-	major := regexVersionMajor
-	client := `Client Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.0", GitCommit:"d3ada0119e776222f11ec7945e6d860061339aad", GitTreeState:"clean", BuildDate:"2017-06-30T09:51:01Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"darwin/amd64"}`
-	server := `Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.0", GitCommit:"d3ada0119e776222f11ec7945e6d860061339aad", GitTreeState:"clean", BuildDate:"2017-07-26T00:12:31Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}`
-
-	cases := []struct {
-		r   *regexp.Regexp
-		s   string
-		exp string
-	}{
-		{r: major, s: server, exp: "1"},
-		{r: minor, s: server, exp: "7"},
-		{r: major, s: client, exp: "1"},
-		{r: minor, s: client, exp: "7"},
-		{r: major, s: "Some unexpected string"},
-		{r: minor}, // Checking that we don't fall over if the string is empty
-	}
-
-	for id, c := range cases {
-		t.Run(strconv.Itoa(id), func(t *testing.T) {
-			m := versionMatch(c.r, c.s)
-			if m != c.exp {
-				t.Fatalf("Got %s expected %s", m, c.exp)
-			}
-		})
-	}
-}
-
 var g string
 var e []error
 var eIndex int


### PR DESCRIPTION
#53 verifyKubeVersion is responsible for the error message. It's functionality has been superseded by getKubeVersion which is uses version information to load appropriate check definition file.

This PR delete calls to verifyKubeVersion and it's support functions.