### PR TITLE
Fixed paths in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 if [ -d /host ]; then
   mkdir -p /host/cfg/
-  yes | cp -rf ./kube-bench/cfg/* /host/cfg/
-  yes | cp -rf ./kube-bench/kube-bench /host/
+  yes | cp -rf ./cfg/* /host/cfg/
+  yes | cp -rf ./kube-bench /host/
   echo "==============================================="
   echo "kube-bench is now installed on your host       "
   echo "Run ./kube-bench to perform a security check   "


### PR DESCRIPTION
The paths in the copy commands for cfg dir and kube-bench binary were not pointing to where those actually lived in the container.

Fix for issue #76 