### PR TITLE
Fixed typo in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 if [ -d /host ]; then
   mkdir -p /host/cfg/
-  yes | cp -rf ./kube-bench/cfg/* /host/cfg/
-  yes | cp -rf ./kube-bench/kube-bench /host/
+  yes | cp -rf /cfg/* /host/cfg/
+  yes | cp -rf /kube-bench /host/
   echo "==============================================="
   echo "kube-bench is now installed on your host       "
   echo "Run ./kube-bench to perform a security check   "


### PR DESCRIPTION
The entrypoint.sh had a typo where it tried coping files from "/kube-bench" instead of just "/".