### PR TITLE
Improve etcd data directory extraction

### DIFF
--- a/cfg/1.8/master.yaml
+++ b/cfg/1.8/master.yaml
@@ -942,7 +942,7 @@ groups:
 
   - id: 1.4.11
     text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-    audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | awk '{print $1}' | xargs stat -c %a
+    audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %a
     tests:
       test_items:
       - flag: "700"

--- a/cfg/1.8/master.yaml
+++ b/cfg/1.8/master.yaml
@@ -942,7 +942,7 @@ groups:
 
   - id: 1.4.11
     text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-    audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | xargs stat -c %a
+    audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | awk '{print $1}' | xargs stat -c %a
     tests:
       test_items:
       - flag: "700"


### PR DESCRIPTION
- If data-dir is not the last argument, the remaining arguments
  are captured preventing the correct checking.

Signed-off-by: Konstantin Semenov <ksemenov@pivotal.io>