### PR TITLE
Allow kubernetes version and config directory to be specified (resolves #107)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -47,7 +47,13 @@ func runChecks(t check.NodeType) {
 		nodetype = "federated"
 	}
 
-	ver := getKubeVersion()
+	var ver string
+	if kubeVersion != "" {
+		ver = kubeVersion
+	} else {
+		ver = getKubeVersion()
+	}
+
 	switch ver {
 	case "1.9", "1.10":
 		continueWithError(nil, fmt.Sprintf("No CIS spec for %s - using tests from CIS 1.2.0 spec for Kubernetes 1.8\n", ver))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,9 +26,10 @@ import (
 
 var (
 	envVarsPrefix      = "KUBE_BENCH"
-	cfgDir             = "./cfg"
 	defaultKubeVersion = "1.6"
+	kubeVersion        string
 	cfgFile            string
+	cfgDir             string
 	jsonFmt            bool
 	pgSQL              bool
 	checkList          string
@@ -77,6 +78,8 @@ func init() {
 		`Run all the checks under this comma-delimited list of groups. Example --group="1.1"`,
 	)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ./cfg/config.yaml)")
+	RootCmd.PersistentFlags().StringVarP(&cfgDir, "config-dir", "D", "./cfg/", "config directory")
+	RootCmd.PersistentFlags().StringVar(&kubeVersion, "version", "", "Manually specify Kubernetes version, automatically detected if unset")
 
 	goflag.CommandLine.VisitAll(func(goflag *goflag.Flag) {
 		RootCmd.PersistentFlags().AddGoFlag(goflag)


### PR DESCRIPTION
Adds in the `--config-dir` and `--version` flags, allowing a user to specify the config directory containing benchmarks, and the target Kubernetes version, respectively.