### PR TITLE
Fail fast in container entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 if [ "$1" == "install" ]; then
   if [ -d /host ]; then
     mkdir -p /host/cfg/


### PR DESCRIPTION
This sets `-e` to exit early if any line in the entrypoint script fails. Should help catch installation issues once Travis tests are set up for the Docker images (#120).