### PR TITLE
Add tip about the `--version` flag to error output

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -219,7 +219,7 @@ func getKubeVersion() string {
 	if err != nil {
 		_, err = exec.LookPath("kubelet")
 		if err != nil {
-			exitWithError(fmt.Errorf("Version check failed: need kubectl or kubelet binaries to get kubernetes version"))
+			exitWithError(fmt.Errorf("Version check failed: need kubectl or kubelet binaries to get kubernetes version.\nAlternately, you can specify the version with --version"))
 		}
 		return getKubeVersionFromKubelet()
 	}
@@ -240,7 +240,7 @@ func getKubeVersionFromKubectl() string {
 func getKubeVersionFromKubelet() string {
 	cmd := exec.Command("kubelet", "--version")
 	out, err := cmd.CombinedOutput()
-	
+
 	if err != nil {
 		continueWithError(fmt.Errorf("%s", out), "")
 	}


### PR DESCRIPTION
If people are trying to use the Docker image to check their cluster, there's a
big likelyhood of them hitting the error message saying that either `kubectl`
or `kubelet` need to be found in order for `kube-bench` to be able to determine
the Kubernetes version in use.

This adds a tip that the version can be specified manually with the `--version`
flag which is a lot easier than having to make a new Docker image with the
right version of `kubelet`/`kubectl` in order for `kube-bench` to work.