### PR TITLE
Addition of missing audit field in 2.2.6 node item

### DIFF
--- a/cfg/1.8/node.yaml
+++ b/cfg/1.8/node.yaml
@@ -411,6 +411,7 @@ groups:
 
     - id: 2.2.6
       text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %U:%G $proxyconf; fi'"
       tests:
         test_items:
         - flag: "root:root"


### PR DESCRIPTION
The audit field in 2.2.6 item of 1.8/node.yaml is missing