### PR TITLE
Inlcude .manifest extension config files for kops & kubespray

### DIFF
--- a/cfg/1.8/config.yaml
+++ b/cfg/1.8/config.yaml
@@ -9,21 +9,27 @@
 
 master:
   apiserver:
+    confs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
     confs: 
       - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
     confs:
       - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 node:


### PR DESCRIPTION
Adds support for kops & kubespray configs that use the .manifest extension instead of .yaml