### PR TITLE
Add link to CIS kubernetes benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <img src="images/kube-bench.png" width="200" alt="kube-bench logo">
 
-kube-bench is a Go application that checks whether Kubernetes is deployed securely by running the checks documented in the CIS Kubernetes Benchmark.
+kube-bench is a Go application that checks whether Kubernetes is deployed securely by running the checks documented in the [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes/).
 
 Tests are configured with YAML files, making this tool easy to update as test specifications evolve. 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   os.Args[0],
 	Short: "Run CIS Benchmarks checks against a Kubernetes deployment",
-	Long:  `This tool runs the CIS Kubernetes Benchmark (http://www.cisecurity.org/benchmark/kubernetes/)`,
+	Long:  `This tool runs the CIS Kubernetes Benchmark (https://www.cisecurity.org/benchmark/kubernetes/)`,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
Thought it would be useful to add a link to the CIS security kubernetes benchmark in the README. Also, corrected the link in the long description of the command. Hope this is useful!