### PR TITLE
Fix issue with kubelet config and unitfile checks

### DIFF
--- a/cfg/1.11/config.yaml
+++ b/cfg/1.11/config.yaml
@@ -9,39 +9,21 @@
 
 master:
   apiserver:
-    confs:
-      - /etc/kubernetes/manifests/kube-apiserver.yaml
-      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
-    confs:
-      - /etc/kubernetes/manifests/kube-scheduler.yaml
-      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
-    confs:
-      - /etc/kubernetes/manifests/kube-controller-manager.yaml
-      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
-    confs:
-      - /etc/kubernetes/manifests/etcd.yaml
-      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 node:
   kubelet:
-    confs:
-     - /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-     - /etc/kubernetes/kubelet.conf
-    defaultconf: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    defaultconf: /etc/kubernetes/kubelet.conf
+    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
   proxy:
-    confs:
-      - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml
-
-

--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -362,7 +362,7 @@ groups:
     - id: 2.2.3
       text: "Ensure that the kubelet service file permissions are set to 644 or
       more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletsvc; then stat -c %a $kubeletsvc; fi'"
       tests:
         bin_op: or
         test_items:
@@ -384,12 +384,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 755 $kubeletconf
+        chmod 755 $kubeletsvc
       scored: true
 
     - id: 2.2.4
       text: "Ensure that the kubelet service file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -397,7 +397,7 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chown root:root $kubeletconf
+        chown root:root $kubeletsvc
       scored: true
 
     - id: 2.2.5

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -79,11 +79,13 @@ func runChecks(nodetype check.NodeType) {
 	typeConf = viper.Sub(string(nodetype))
 	binmap := getBinaries(typeConf)
 	confmap := getConfigFiles(typeConf)
+	svcmap := getServiceFiles(typeConf)
 
 	// Variable substitutions. Replace all occurrences of variables in controls files.
 	s := string(in)
 	s = makeSubstitutions(s, "bin", binmap)
 	s = makeSubstitutions(s, "conf", confmap)
+	s = makeSubstitutions(s, "svc", svcmap)
 
 	controls, err := check.NewControls(nodetype, []byte(s))
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue with the current implementation which check only the kubelet config file for both kubelet config checks (2.2.1 and 2.2.2) and kubelet service file (2.2.3 and 2.2.4) which causes wrong results.