### PR TITLE
Fixing checks 2.2.9 and 2.2.10 on 1.11 nodes.

### DIFF
--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -460,7 +460,7 @@ groups:
 
     - id: 2.2.9
       text: "Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $/var/lib/kubelet/config.yaml; then stat -c %U:%G $/var/lib/kubelet/config.yaml; fi'"
+      audit: "/bin/sh -c 'if test -e /var/lib/kubelet/config.yaml; then stat -c %U:%G /var/lib/kubelet/config.yaml; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -472,7 +472,7 @@ groups:
 
     - id: 2.2.10
       text: "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $/var/lib/kubelet/config.yaml; then stat -c %a $/var/lib/kubelet/config.yaml; fi'"
+      audit: "/bin/sh -c 'if test -e /var/lib/kubelet/config.yaml; then stat -c %a /var/lib/kubelet/config.yaml; fi'"
       tests:
         bin_op: or
         test_items:


### PR DESCRIPTION
Path to kubelet configuration was accidentally prefixed with a dollar
symbol (probably as a result of copying some other test that used
variable name).
After removing the dollar sign from paths both checks pass on conforming
deployment.