### PR TITLE
Fixing 1.3.7 on 1.11 master.

### DIFF
--- a/cfg/1.11/master.yaml
+++ b/cfg/1.11/master.yaml
@@ -790,6 +790,7 @@ groups:
     text: "Ensure that the --address argument is set to 127.0.0.1 (Scored)"
     audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
     tests:
+      bin_op: or
       test_items:
       - flag: "--address"
         compare:


### PR DESCRIPTION
With multiple test items operator defaults to "and". In case of 1.3.7
the tests check whether --address flag is either set to 127.0.0.1 or not
set at all. Those conditions cannot be met at the same time.