### PR TITLE
Correct readme for 1.11 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run --pid=host -t -v path/to/my-config.yaml:/opt/kube-bench/cfg/config.ya
 Run the master check
 
 ```
-kubectl run --rm -i -t kube-bench-master --image=aquasec/kube-bench:latest --restart=Never --overrides="{ \"apiVersion\": \"v1\", \"spec\": { \"hostPID\": true, \"nodeSelector\": { \"kubernetes.io/role\": \"master\" }, \"tolerations\": [ { \"key\": \"node-role.kubernetes.io/master\", \"operator\": \"Exists\", \"effect\": \"NoSchedule\" } ] } }" -- master --version 1.11
+kubectl run --rm -i -t kube-bench-master --image=aquasec/kube-bench:latest --restart=Never --overrides="{ \"apiVersion\": \"v1\", \"spec\": { \"hostPID\": true, \"nodeSelector\": { \"node-role.kubernetes.io/master\": \"\" }, \"tolerations\": [ { \"key\": \"node-role.kubernetes.io/master\", \"operator\": \"Exists\", \"effect\": \"NoSchedule\" } ] } }" -- master --version 1.11
 ```
 
 Run the node check


### PR DESCRIPTION
Signed-off-by: Johannes M. Scheuermann <joh.scheuer@gmail.com>

In the latest Kubernetes releases the node label for the master node has changed from: `"kubernetes.io/role": "master"` to `"node-role.kubernetes.io/master": ""`. This PR corrects the `labelSelector` of the `kubectl run ..`command to work on clusters that are bootstrapped with `kubeadm`.