### PR TITLE
Support kube-controller{-manager} as well

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -43,6 +43,7 @@ master:
   controllermanager:
     bins:
       - "kube-controller-manager"
+      - "kube-controller"
       - "hyperkube controller-manager"
       - "controller-manager"
     confs:


### PR DESCRIPTION
In some cases, the ps -C output for long processes like
kube-controller-manager may be truncated, meaning the search should be
for the truncated prefix.

This occurs with GKE and k8s 1.11 on minikube.

This fixes https://sysdig.atlassian.net/browse/SSPROD-1253.