### PR TITLE
Added missing "=" to master.yaml

### DIFF
--- a/cfg/1.11/master.yaml
+++ b/cfg/1.11/master.yaml
@@ -179,7 +179,7 @@ groups:
       Edit the API server pod specification file $apiserverconf
       on the master node and set the --enable-admission-plugins to
       include AlwaysPullImages.
-      --enable-admission-plugins...,AlwaysPullImages,...
+      --enable-admission-plugins=...,AlwaysPullImages,...
     scored: true
 
   - id: 1.1.12


### PR DESCRIPTION
In the remediation of 1.1.11 the flag --enable-admission-plugins was missing a =