### PR TITLE
Changed 1.1.14 to not fail when flag is not set

### DIFF
--- a/cfg/1.11/master.yaml
+++ b/cfg/1.11/master.yaml
@@ -220,12 +220,15 @@ groups:
     text: "Ensure that the admission control plugin NamespaceLifecycle is set (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
+      bin_op: or
       test_items:
       - flag: "--disable-admission-plugins"
         compare:
           op: nothave
           value: "NamespaceLifecycle"
         set: true
+      - flag: "--disable-admission-plugins"
+        set: false
     remediation: |
       Edit the API server pod specification file $apiserverconf
       on the master node and set the --disable-admission-plugins parameter to


### PR DESCRIPTION
Added another test item that checks whether --disable-admission-plugins is not set and an "or" bin_op. 
This causes check 1.1.14 to be successful when the flag is not set, while still failing when the flag is set and includes the value NamespaceLifecycle

Fixes #192 