### PR TITLE
Only get runningVersion if --version has not been provided

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -44,9 +44,12 @@ func runChecks(nodetype check.NodeType) {
 		file = federatedFile
 	}
 
-	runningVersion, err := getKubeVersion()
-	if err != nil && kubeVersion == "" {
-		exitWithError(fmt.Errorf("Version check failed: %s\nAlternatively, you can specify the version with --version", err))
+	runningVersion := ""
+	if kubeVersion == "" {
+		runningVersion, err = getKubeVersion()
+		if err != nil {
+			exitWithError(fmt.Errorf("Version check failed: %s\nAlternatively, you can specify the version with --version", err))
+		}
 	}
 	path, err := getConfigFilePath(kubeVersion, runningVersion, file)
 	if err != nil {


### PR DESCRIPTION
Only get runningVersion in [`runChecks()`](https://github.com/aquasecurity/kube-bench/blob/master/cmd/common.go#L47) if kubeVersion has not already been provided.

This should fix #176 

Signed-off-by: Weston Steimel <weston.steimel@gmail.com>