### PR TITLE
Add mount our own configuration

### DIFF
--- a/job-master.yaml
+++ b/job-master.yaml
@@ -1,10 +1,94 @@
+--- 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-bench
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: privileged-psp-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp-user
+subjects:
+- kind: ServiceAccount
+  name: kube-bench
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-bench-config
+data:
+  config.yaml: |
+    master:
+      components:
+        - apiserver
+        - scheduler
+        - controllermanager
+        - etcd 
+        # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
+        - kubernetes
+
+      kubernetes:
+        defaultconf: /etc/kubernetes/manifests/
+
+      apiserver:
+        bins:
+          - "hyperkube apiserver"
+        defaultconf: /etc/kubernetes/manifests/k8s-api-server.yaml
+
+      scheduler:
+        bins:
+          - "hyperkube scheduler"
+        defaultconf: /etc/kubernetes/manifests/k8s-scheduler.yaml
+
+      controllermanager:
+        bins:
+          - "hyperkube controller-manager"
+        defaultconf: /etc/kubernetes/manifests/k8s-controller-manager.yaml
+
+      etcd:
+        optional: true
+        bins:
+          - "etcd"
+        defaultconf: /etc/systemd/system/etcd3.service
+
+    node:
+      components:
+        - kubelet
+        - proxy
+        # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
+        - kubernetes
+
+      kubernetes:
+        defaultconf: /etc/kubernetes/config/    
+
+      kubelet:
+        bins:
+          - "hyperkube kubelet"
+        defaultsvc: /etc/systemd/system/k8s-kubelet.service
+        defaultconf: /etc/systemd/system/k8s-kubelet.service
+
+      proxy:
+        bins:
+          - "hyperkube proxy"
+        confs:
+          - /etc/kubernetes/config/proxy-config.yml
+          - /srv/kube-proxy-ds.yaml
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: kube-bench-master
+  namespace: default
 spec:
   template:
     spec:
+      serviceAccount: kube-bench
       hostPID: true
       nodeSelector: 
         node-role.kubernetes.io/master: "" 
@@ -14,25 +98,29 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-bench
-        image: aquasec/kube-bench:latest
-        command: ["kube-bench","master"]
+        image: quay.io/giantswarm/kube-bench:0.0.1
+        args:
+        - master
+        - --version
+        - "1.11"
+        - --json
+        - "true"
         volumeMounts:
+        - mountPath: /opt/kube-bench/cfg/1.11/config.yaml
+          name: config
+          subPath: config.yaml
         - name: var-lib-etcd
           mountPath: /var/lib/etcd
         - name: etc-kubernetes
-          mountPath: /etc/kubernetes
-          # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
-          # You can omit this mount if you specify --version as part of the command.
-        - name: usr-bin
-          mountPath: /usr/bin
+          mountPath: /etc
       restartPolicy: Never
       volumes:
+      - name: config
+        configMap:
+          name: kube-bench-config
       - name: var-lib-etcd
         hostPath:
           path: "/var/lib/etcd"
       - name: etc-kubernetes
         hostPath:
-          path: "/etc/kubernetes"
-      - name: usr-bin
-        hostPath:
-          path: "/usr/bin"
+          path: "/etc"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4818

It allows us to run directly kube bench with our own setup. I have tried to mount a configmap so image can be the same one but it fails parsing YAML (I tried to fix but I dont want to expend too much time), so now it uses our own image