### PR TITLE
Bugfix: Logging warning instead of printing

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -33,20 +33,6 @@ func init() {
 	statFunc = os.Stat
 }
 
-func printlnWarn(msg string) {
-	fmt.Fprintf(os.Stderr, "[%s] %s\n",
-		colors[check.WARN].Sprintf("%s", check.WARN),
-		msg,
-	)
-}
-
-func sprintlnWarn(msg string) string {
-	return fmt.Sprintf("[%s] %s",
-		colors[check.WARN].Sprintf("%s", check.WARN),
-		msg,
-	)
-}
-
 func exitWithError(err error) {
 	fmt.Fprintf(os.Stderr, "\n%v\n", err)
 	os.Exit(1)
@@ -336,7 +322,7 @@ func getVersionFromKubectlOutput(s string) string {
 	serverVersionRe := regexp.MustCompile(`Server Version: v(\d+.\d+)`)
 	subs := serverVersionRe.FindStringSubmatch(s)
 	if len(subs) < 2 {
-		printlnWarn(fmt.Sprintf("Unable to get kubectl version, using default version: %s", defaultKubeVersion))
+		glog.V(1).Info(fmt.Sprintf("Unable to get Kubernetes version from kubectl, using default version: %s", defaultKubeVersion))
 		return defaultKubeVersion
 	}
 	return subs[1]
@@ -346,7 +332,7 @@ func getVersionFromKubeletOutput(s string) string {
 	serverVersionRe := regexp.MustCompile(`Kubernetes v(\d+.\d+)`)
 	subs := serverVersionRe.FindStringSubmatch(s)
 	if len(subs) < 2 {
-		printlnWarn(fmt.Sprintf("Unable to get kubelet version, using default version: %s", defaultKubeVersion))
+		glog.V(1).Info(fmt.Sprintf("Unable to get Kubernetes version from kubelet, using default version: %s", defaultKubeVersion))
 		return defaultKubeVersion
 	}
 	return subs[1]


### PR DESCRIPTION
Made all the warnings to be logged and not printed, so when using the json flag the output will be only in json format.

fix #217