### PR TITLE
run the kubelet binary to get the kubernetes version on pks environment

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -303,6 +303,12 @@ func getKubeVersion() (string, error) {
 	if err != nil {
 		_, err = exec.LookPath("kubelet")
 		if err != nil {
+			// It might be a PKS platform
+			cmd := exec.Command("/bin/sh", "-c", "/var/vcap/data/packages/kubernetes/*/bin/kubelet --version")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				return getVersionFromKubeletOutput(string(out)), nil
+			}
 			return "", fmt.Errorf("need kubectl or kubelet binaries to get kubernetes version")
 		}
 		return getKubeVersionFromKubelet(), nil

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -303,7 +303,7 @@ func getKubeVersion() (string, error) {
 	if err != nil {
 		_, err = exec.LookPath("kubelet")
 		if err != nil {
-			// It might be a PKS platform
+			// It might be a PKS platform. The * in the path is a wildcard for the node ID.
 			cmd := exec.Command("/bin/sh", "-c", "/var/vcap/data/packages/kubernetes/*/bin/kubelet --version")
 			out, err := cmd.CombinedOutput()
 			if err == nil {


### PR DESCRIPTION
On PKS platform kubelet is not in the path, so kube-bench fails to get the version and doesn't scan the host. The suggested solution was to run the kubelet binary, assuming it will always be found at /var/vcap/data/packages/kubernetes/*/bin/kubelet.
The fix was tested on PKS platform and it worked fine. 