### PR TITLE
search for the kubelet binary when it is not in the path

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -289,6 +289,12 @@ func getKubeVersion() (string, error) {
 	if err != nil {
 		_, err = exec.LookPath("kubelet")
 		if err != nil {
+			// Search for the kubelet binary all over the filesystem and run the first match to get the kubernetes version
+			cmd := exec.Command("/bin/sh", "-c", "`find / -type f -executable -name kubelet 2>/dev/null | grep -m1 .` --version")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				return getVersionFromKubeletOutput(string(out)), nil
+			}
 			return "", fmt.Errorf("need kubectl or kubelet binaries to get kubernetes version")
 		}
 		return getKubeVersionFromKubelet(), nil


### PR DESCRIPTION
Kube-bench doesn't scan the host when kubelet is not in path. We encountered with this issue on different PKS, GKE and AKS platforms.
One way to get the kubernetes version is by getting the kubelet path from the running process using ps
`ps -eo cmd | grep kubelet | awk '{print $1}' | grep kubelet` --version

And another way to get the kubernetes version is by finding the kubelet binary on the file system using find command
"`find / -type f -executable -name kubelet 2>/dev/null | grep -m1 .` --version"

I chose the second way (searching the fs) because it looks to me less risky then the first way (using ps).

