### PR TITLE
Only find flags on the process we really want

### DIFF
--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -10,7 +10,7 @@ groups:
   checks:
   - id: 2.1.1
     text: "Ensure that the --allow-privileged argument is set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--allow-privileged"
@@ -29,7 +29,7 @@ groups:
 
   - id: 2.1.2
     text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--anonymous-auth"
@@ -51,7 +51,7 @@ groups:
 
   - id: 2.1.3
     text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--authorization-mode"
@@ -72,7 +72,7 @@ groups:
 
   - id: 2.1.4
     text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--client-ca-file"
@@ -91,7 +91,7 @@ groups:
 
   - id: 2.1.5
     text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--read-only-port"
@@ -112,7 +112,7 @@ groups:
 
   - id: 2.1.6
     text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--streaming-connection-idle-timeout"
@@ -134,7 +134,7 @@ groups:
 
   - id: 2.1.7
     text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--protect-kernel-defaults"
@@ -155,7 +155,7 @@ groups:
 
   - id: 2.1.8
     text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       bin_op: or
       test_items:
@@ -179,7 +179,7 @@ groups:
 
   - id: 2.1.9
     text: "Ensure that the --hostname-override argument is not set (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--hostname-override"
@@ -195,7 +195,7 @@ groups:
 
   - id: 2.1.10
     text: "Ensure that the --event-qps argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--event-qps"
@@ -216,7 +216,7 @@ groups:
 
   - id: 2.1.11
     text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       bin_op: and
       test_items:
@@ -240,7 +240,7 @@ groups:
 
   - id: 2.1.12
     text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       bin_op: or
       test_items:
@@ -262,7 +262,7 @@ groups:
 
   - id: 2.1.13
     text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--rotate-certificates"
@@ -281,7 +281,7 @@ groups:
 
   - id: 2.1.14
     text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "RotateKubeletServerCertificate"
@@ -300,7 +300,7 @@ groups:
 
   - id: 2.1.15
     text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Not Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--tls-cipher-suites"

--- a/cfg/1.8/node.yaml
+++ b/cfg/1.8/node.yaml
@@ -10,7 +10,7 @@ groups:
   checks:
   - id: 2.1.1
     text: "Ensure that the --allow-privileged argument is set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--allow-privileged"
@@ -29,7 +29,7 @@ groups:
 
   - id: 2.1.2
     text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--anonymous-auth"
@@ -48,7 +48,7 @@ groups:
 
   - id: 2.1.3
     text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--authorization-mode"
@@ -67,7 +67,7 @@ groups:
 
   - id: 2.1.4
     text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--client-ca-file"
@@ -83,7 +83,7 @@ groups:
 
   - id: 2.1.5
     text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--read-only-port"
@@ -102,7 +102,7 @@ groups:
 
   - id: 2.1.6
     text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--streaming-connection-idle-timeout"
@@ -121,7 +121,7 @@ groups:
 
   - id: 2.1.7
     text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--protect-kernel-defaults"
@@ -140,7 +140,7 @@ groups:
 
   - id: 2.1.8
     text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       bin_op: or
       test_items:
@@ -160,7 +160,7 @@ groups:
 
   - id: 2.1.9
     text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--keep-terminated-pod-volumes"
@@ -179,7 +179,7 @@ groups:
 
   - id: 2.1.10
     text: "Ensure that the --hostname-override argument is not set (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--hostname-override"
@@ -195,7 +195,7 @@ groups:
 
   - id: 2.1.11
     text: "Ensure that the --event-qps argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--event-qps"
@@ -214,7 +214,7 @@ groups:
 
   - id: 2.1.12
     text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--tls-cert-file"
@@ -236,7 +236,7 @@ groups:
 
   - id: 2.1.13
     text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--cadvisor-port"
@@ -255,7 +255,7 @@ groups:
 
   - id: 2.1.14
     text: "Ensure that the RotateKubeletClientCertificate argument is set to true"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "RotateKubeletClientCertificate"
@@ -275,7 +275,7 @@ groups:
 
   - id: 2.1.15
     text: "Ensure that the RotateKubeletServerCertificate argument is set to true"
-    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "RotateKubeletServerCertificate"


### PR DESCRIPTION
Fix for #194 (which it turns out can affect many of the 2.1.* tests, not just 2.1.4)

Using the -C flag on ps should return only the processes with that command name, rather than any process that happens to have something with any argument that happens to match. 

@ttousai please could you try this out and see if you agree? 

I've only done this for the last two sets of config files since I doubt anyone is seriously using config files for Kubernetes 1.6 or 1.7 at this point (we could consider retiring those, but that's a separate matter). 