### PR TITLE
Fix issues with checks for kubelet configuration files

### DIFF
--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -320,7 +320,7 @@ groups:
     - id: 2.2.1
       text: "Ensure that the kubelet.conf file permissions are set to 644 or
       more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c %a $kubeletkubeconfig; fi'"
       tests:
         bin_op: or
         test_items:
@@ -342,12 +342,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 644 $kubeletconf
+        chmod 644 $kubeletkubeconfig
       scored: true
 
     - id: 2.2.2
       text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'"
       tests:
         test_items:
           - flag: "root:root"
@@ -358,7 +358,7 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chown root:root $kubeletconf
+        chown root:root $kubeletkubeconfig
       scored: true
 
     - id: 2.2.3
@@ -404,7 +404,7 @@ groups:
 
     - id: 2.2.5
       text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c %a $proxykubeconfig; fi'"
       tests:
         bin_op: or
         test_items:
@@ -426,12 +426,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 644 $proxyconf
+        chmod 644 $proxykubeconfig
       scored: true
 
     - id: 2.2.6
       text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %U:%G $proxyconf; fi'"
+      audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -439,7 +439,7 @@ groups:
       remediation: |
           Run the below command (based on the file location on your system) on the each worker
           node. For example,
-          chown root:root $proxyconf
+          chown root:root $proxykubeconfig
       scored: true
 
     - id: 2.2.7
@@ -462,19 +462,19 @@ groups:
 
     - id: 2.2.9
       text: "Ensure that the kubelet configuration file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e /var/lib/kubelet/config.yaml; then stat -c %U:%G /var/lib/kubelet/config.yaml; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
       tests:
         test_items:
         - flag: "root:root"
           set: true
       remediation: |
         Run the following command (using the config file location identied in the Audit step)
-        chown root:root /etc/kubernetes/kubelet.conf
+        chown root:root $kubeletconf
       scored: true
 
     - id: 2.2.10
       text: "Ensure that the kubelet configuration file has permissions set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e /var/lib/kubelet/config.yaml; then stat -c %a /var/lib/kubelet/config.yaml; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
       tests:
         bin_op: or
         test_items:
@@ -495,5 +495,5 @@ groups:
           set: true
       remediation: |
         Run the following command (using the config file location identied in the Audit step)
-        chmod 644 /var/lib/kubelet/config.yaml
+        chmod 644 $kubeletconf
       scored: true

--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -19,7 +19,7 @@ groups:
           value: false
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --allow-privileged=false
       Based on your system, restart the kubelet service. For example:
@@ -41,7 +41,7 @@ groups:
       If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to
       false .
       If using executable arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --anonymous-auth=false
       Based on your system, restart the kubelet service. For example:
@@ -62,7 +62,7 @@ groups:
     remediation: |
       If using a Kubelet config file, edit the file to set authorization: mode to Webhook.
       If using executable arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_AUTHZ_ARGS variable.
       --authorization-mode=Webhook
       Based on your system, restart the kubelet service. For example:
@@ -81,7 +81,7 @@ groups:
       If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to
       the location of the client CA file.
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_AUTHZ_ARGS variable.
       --client-ca-file=<path/to/client-ca-file>
       Based on your system, restart the kubelet service. For example:
@@ -102,7 +102,7 @@ groups:
     remediation: |
       If using a Kubelet config file, edit the file to set readOnlyPort to 0 .
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --read-only-port=0
       Based on your system, restart the kubelet service. For example:
@@ -124,7 +124,7 @@ groups:
       If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
       value other than 0.
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --streaming-connection-idle-timeout=5m
       Based on your system, restart the kubelet service. For example:
@@ -145,7 +145,7 @@ groups:
     remediation: |
       If using a Kubelet config file, edit the file to set protectKernelDefaults: true .
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --protect-kernel-defaults=true
       Based on your system, restart the kubelet service. For example:
@@ -169,7 +169,7 @@ groups:
     remediation: |
       If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true .
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       remove the --make-iptables-util-chains argument from the
       KUBELET_SYSTEM_PODS_ARGS variable.
       Based on your system, restart the kubelet service. For example:
@@ -185,7 +185,7 @@ groups:
       - flag: "--hostname-override"
         set: false
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and remove the --hostname-override argument from the
       KUBELET_SYSTEM_PODS_ARGS variable.
       Based on your system, restart the kubelet service. For example:
@@ -206,7 +206,7 @@ groups:
     remediation: |
       If using a Kubelet config file, edit the file to set eventRecordQPS: 0 .
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --event-qps=0
       Based on your system, restart the kubelet service. For example:
@@ -229,7 +229,7 @@ groups:
       file to use to identify this Kubelet, and tlsPrivateKeyFile to the location of the
       corresponding private key file.
       If using command line arguments, edit the kubelet service file
-      $kubeletconf on each worker node and
+      $kubeletsvc on each worker node and
       set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
       --tls-cert-file=<path/to/tls-certificate-file>
       file=<path/to/tls-key-file>
@@ -252,7 +252,7 @@ groups:
       - flag: "--cadvisor-port"
         set: false
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_CADVISOR_ARGS variable.
       --cadvisor-port=0
       Based on your system, restart the kubelet service. For example:
@@ -272,7 +272,7 @@ groups:
         set: true
     remediation: |
       If using a Kubelet config file, edit the file to add the line rotateCertificates: true.
-      If using command line arguments, edit the kubelet service file $kubeletconf 
+      If using command line arguments, edit the kubelet service file $kubeletsvc 
       on each worker node and add --rotate-certificates=true argument to the KUBELET_CERTIFICATE_ARGS variable.
       Based on your system, restart the kubelet service. For example:
       systemctl daemon-reload
@@ -290,7 +290,7 @@ groups:
           value: true
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
       --feature-gates=RotateKubeletServerCertificate=true
       Based on your system, restart the kubelet service. For example:

--- a/cfg/1.8/config.yaml
+++ b/cfg/1.8/config.yaml
@@ -9,36 +9,13 @@
 
 master:
   apiserver:
-    confs:
-      - /etc/kubernetes/manifests/kube-apiserver.yaml
-      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
-    confs: 
-      - /etc/kubernetes/manifests/kube-scheduler.yaml
-      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
-    confs:
-      - /etc/kubernetes/manifests/kube-controller-manager.yaml
-      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
-    confs:
-      - /etc/kubernetes/manifests/etcd.yaml
-      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
-
-node:
-  kubelet:
-    confs:
-     - /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    defaultconf: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-  
-  proxy:
-    confs:
-      - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
-    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.8/config.yaml
+++ b/cfg/1.8/config.yaml
@@ -9,13 +9,34 @@
 
 master:
   apiserver:
+    confs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
+    confs: 
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
+    confs:
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
+    confs:
+      - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
+
+node:
+  kubelet:
+    defaultconf: /var/lib/kubelet/config.yaml
+    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    defaultkubeconfig: /etc/kubernetes/kubelet.conf
+  
+  proxy:
+    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.8/node.yaml
+++ b/cfg/1.8/node.yaml
@@ -297,7 +297,7 @@ groups:
     - id: 2.2.1
       text: "Ensure that the kubelet.conf file permissions are set to 644 or
       more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c %a $kubeletkubeconfig; fi'"
       tests:
         bin_op: or
         test_items:
@@ -319,12 +319,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 644 $kubeletconf
+        chmod 644 $kubeletkubeconfig
       scored: true
 
     - id: 2.2.2
       text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'"
       tests:
         test_items:
           - flag: "root:root"
@@ -335,7 +335,7 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chown root:root $kubeletconf
+        chown root:root $kubeletkubeconfig
       scored: true
 
     - id: 2.2.3
@@ -382,7 +382,7 @@ groups:
     - id: 2.2.5
       text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more
       restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c %a $proxykubeconfig; fi'"
       tests:
         bin_op: or
         test_items:
@@ -404,12 +404,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 644 $proxyconf
+        chmod 644 $proxykubeconfig
       scored: true
 
     - id: 2.2.6
       text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %U:%G $proxyconf; fi'"
+      audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -417,7 +417,7 @@ groups:
       remediation: |
           Run the below command (based on the file location on your system) on the each worker
           node. For example,
-          chown root:root $proxyconf
+          chown root:root $proxykubeconfig
       scored: true
 
     - id: 2.2.7

--- a/cfg/1.8/node.yaml
+++ b/cfg/1.8/node.yaml
@@ -19,7 +19,7 @@ groups:
           value: false
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --allow-privileged=false
       Based on your system, restart the kubelet service. For example:
@@ -38,7 +38,7 @@ groups:
           value: false
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --anonymous-auth=false
       Based on your system, restart the kubelet service. For example:
@@ -57,7 +57,7 @@ groups:
           value: "AlwaysAllow"
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
       --authorization-mode=Webhook
       Based on your system, restart the kubelet service. For example:
@@ -73,7 +73,7 @@ groups:
       - flag: "--client-ca-file"
         set: true 
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
       --client-ca-file=<path/to/client-ca-file>
       Based on your system, restart the kubelet service. For example:
@@ -92,7 +92,7 @@ groups:
           value: 0
         set: true 
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --read-only-port=0
       Based on your system, restart the kubelet service. For example:
@@ -111,7 +111,7 @@ groups:
           value: 0
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --streaming-connection-idle-timeout=5m
       Based on your system, restart the kubelet service. For example:
@@ -130,7 +130,7 @@ groups:
           value: true
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --protect-kernel-defaults=true
       Based on your system, restart the kubelet service. For example:
@@ -150,7 +150,7 @@ groups:
           value: true
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and remove the --make-iptables-util-chains argument from the
       KUBELET_SYSTEM_PODS_ARGS variable.
       Based on your system, restart the kubelet service. For example:
@@ -169,7 +169,7 @@ groups:
           value: false
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --keep-terminated-pod-volumes=false
       Based on your system, restart the kubelet service. For example:
@@ -185,7 +185,7 @@ groups:
       - flag: "--hostname-override"
         set: false
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and remove the --hostname-override argument from the
       KUBELET_SYSTEM_PODS_ARGS variable.
       Based on your system, restart the kubelet service. For example:
@@ -204,7 +204,7 @@ groups:
           value: 0
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
       --event-qps=0
       Based on your system, restart the kubelet service. For example:
@@ -223,8 +223,7 @@ groups:
         set: true
     remediation: |
       Follow the Kubernetes documentation and set up the TLS connection on the Kubelet.
-      Then edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-
-      kubeadm.conf on each worker node and set the below parameters in
+      Then edit the kubelet service file $kubeletsvc on each worker node and set the below parameters in
       KUBELET_CERTIFICATE_ARGS variable.
       --tls-cert-file=<path/to/tls-certificate-file>
       file=<path/to/tls-key-file>
@@ -245,7 +244,7 @@ groups:
           value: 0
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_CADVISOR_ARGS variable.
       --cadvisor-port=0
       Based on your system, restart the kubelet service. For example:
@@ -264,7 +263,7 @@ groups:
           value: true
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and remove the --feature-
       gates=RotateKubeletClientCertificate=false argument from the
       KUBELET_CERTIFICATE_ARGS variable.
@@ -284,7 +283,7 @@ groups:
           value: true
         set: true
     remediation: |
-      Edit the kubelet service file $kubeletconf
+      Edit the kubelet service file $kubeletsvc
       on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
       --feature-gates=RotateKubeletServerCertificate=true
       Based on your system, restart the kubelet service. For example:
@@ -336,13 +335,13 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chown root:root /etc/kubernetes/kubelet.conf
+        chown root:root $kubeletconf
       scored: true
 
     - id: 2.2.3
       text: "Ensure that the kubelet service file permissions are set to 644 or
       more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletsvc; then stat -c %a $kubeletsvc; fi'"
       tests:
         bin_op: or
         test_items:
@@ -364,12 +363,12 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chmod 755 $kubeletconf
+        chmod 755 $kubeletsvc
       scored: true
 
     - id: 2.2.4
       text: "2.2.4 Ensure that the kubelet service file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      audit: "/bin/sh -c 'if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'"
       tests:
         test_items:
         - flag: "root:root"
@@ -377,7 +376,7 @@ groups:
       remediation: |
         Run the below command (based on the file location on your system) on the each worker
         node. For example,
-        chown root:root $kubeletconf
+        chown root:root $kubeletsvc
       scored: true
 
     - id: 2.2.5

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -82,6 +82,7 @@ node:
       - /etc/kubernetes/kubelet.conf
       - /etc/kubernetes/kubelet 
     defaultconf: "/etc/kubernetes/kubelet.conf"
+    defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
 
   proxy:
     bins:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -78,11 +78,9 @@ node:
     bins:
       - "hyperkube kubelet"
       - "kubelet"
-    confs:
-      - /etc/kubernetes/kubelet.conf
-      - /etc/kubernetes/kubelet 
-    defaultconf: "/etc/kubernetes/kubelet.conf"
+    defaultconf: "/var/lib/kubelet/config.yaml"
     defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+    defaultkubeconfig: "/etc/kubernetes/kubelet.conf"
 
   proxy:
     bins:
@@ -90,9 +88,9 @@ node:
       - "hyperkube proxy"
       - "proxy"
     confs:
-      - /etc/kubernetes/proxy.conf
       - /etc/kubernetes/proxy
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    defaultkubeconfig: "/etc/kubernetes/proxy.conf"
 
 federated:
   components:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -83,12 +83,14 @@ func runChecks(nodetype check.NodeType) {
 	binmap := getBinaries(typeConf)
 	confmap := getConfigFiles(typeConf)
 	svcmap := getServiceFiles(typeConf)
+	kubeconfmap := getKubeConfigFiles(typeConf)
 
 	// Variable substitutions. Replace all occurrences of variables in controls files.
 	s := string(in)
 	s = makeSubstitutions(s, "bin", binmap)
 	s = makeSubstitutions(s, "conf", confmap)
 	s = makeSubstitutions(s, "svc", svcmap)
+	s = makeSubstitutions(s, "kubeconfig", kubeconfmap)
 
 	controls, err := check.NewControls(nodetype, []byte(s))
 	if err != nil {


### PR DESCRIPTION
This is a more detailed solution to the issue reported in the PR #208. It fixes issues with variable substitutions for node benchmarks.

There are 3 major config files for kubelets k8s nodes:
- /etc/kubernetes/kubelet.conf ($kubeletkubeconfig)
- /var/lib/kubelet.config.yaml ($kubeletconf)
- /etc/systemd/system/kubelet.service.d/10-kubeadm.conf ($kubeletsvc)

In the previous versions of kube-bench there was no distinction between these files and results of running node checks were misleading. This PR adds the distinction and also adds support for a new type of variable `kubeconfig`.