### PR TITLE
Clean up OCP benchmark config.

### DIFF
--- a/cfg/ocp-3.10/config.yaml
+++ b/cfg/ocp-3.10/config.yaml
@@ -11,25 +11,20 @@ master:
   apiserver:
     bins:
       - openshift start master api
-    defaultconf: /etc/origin/master/master-config.yaml
 
   scheduler:
     bins:
       - openshift start master controllers
-    defaultconf: /etc/origin/master/master-config.yaml
 
   controllermanager:
     bins:
       - openshift start master controllers
-    defaultconf: /etc/origin/master/master-config.yaml
-
-  etcd:
-    defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 node:
   kubelet:
-    defaultconf: /etc/kubernetes/kubelet.conf
-    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    bins:
+      - openshift start network
 
   proxy:
-    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    bins:
+      - openshift start network

--- a/cfg/ocp-3.10/master.yaml
+++ b/cfg/ocp-3.10/master.yaml
@@ -1043,7 +1043,7 @@ groups:
     remediation: |
       On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
       from the below command:
-      ps -ef | grep $etcdbin
+      ps -ef | grep etcd
       Run the below command (based on the etcd data directory found above). For example,
       chmod 700 /var/lib/etcd
     scored: true


### PR DESCRIPTION
The OCP benchmarks uses configs only names of OCP component binaries. 

OCP configuration file paths are hardcoded into the benchmarks so there is no need to specify them in the `cfg/ocp-3.10/config.yaml` at the moment.

This commit cleans up the OCP config by removing all configurations except those component binaries required to run kube-bench on OCP installations and adding missing ones.