### PR TITLE
Adds master node detection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ kube-bench
 *.swp
 vendor
 dist
+.vscode/
+hack/kind.test.yaml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,30 @@
 
 
 [[projects]]
+  digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = "UT"
   revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:38c783cf85b9454cc02a1a8319239800ed0af6c1c864adf19cea0539e134adad"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4da3e2cfbabc9f751898f250b49f2439785783a1"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:145eff5207977eb95c3649a27cdc2e467d8a1c104810bc12b6a53745a91d823a"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -29,106 +36,140 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "UT"
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:510a2b056950ed12b4f3ac704ee1b34fd1920cb5b26f60f98d069de89c60adb7"
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
-    "dialects/postgres"
+    "dialects/postgres",
   ]
+  pruneopts = "UT"
   revision = "5174cc5c242a728b435ea2be8a2f7f998e15429b"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:2cf1e05311b662e68d938f6655c6c5a44ae0e6b3995e390c75fcd8224afa48df"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1c35d901db3da928c72a72d8458480cc9ade058f"
 
 [[projects]]
+  digest = "1:38dd5cee5306173bfe78f8c401edec1e08f772551bee95a85617b4e39347e366"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "hstore",
-    "oid"
+    "oid",
   ]
+  pruneopts = "UT"
   revision = "83612a56d3dd153a94a629cd64925371c9adad78"
 
 [[projects]]
+  digest = "1:9cbfcfd1ec741817698b844d17b523f54682a5f7c8683b1ec62b6b6542143240"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = "UT"
   revision = "49d762b9817ba1c2e9d0c69183c2b4a8b8f1d934"
 
 [[projects]]
+  digest = "1:31fcf8f5f8f6cc36ef11182c0a0f63ba464e1a7ad9f0e92a7cf46f38bfc0adfd"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5411d3eea5978e6cdc258b30de592b60df6aba96"
 
 [[projects]]
+  digest = "1:fa610f9fe6a93f4a75e64c83673dfff9bf1a34bbb21e6102021b6bc7850834a3"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "57fdcb988a5c543893cc61bce354a6e24ab70022"
 
 [[projects]]
+  digest = "1:56a0bd1a1f3809171d1abe0bfd389558be0cd672e858e1f831b88f806aa8764f"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "UT"
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
+  digest = "1:128af710970a788bb2348dbcdde6b86fa41f92086297f909d659b6d3affc2902"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0131db6d737cfbbfb678f8b7d92e55e27ce46224"
 
 [[projects]]
+  digest = "1:1fccaaeae58b2a2f1af4dbf7eee92ff14f222e161d143bfd20082ef664f91216"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
+  pruneopts = "UT"
   revision = "57afd63c68602b63ed976de00dd066ccb3c319db"
 
 [[projects]]
+  digest = "1:9b28ee2984c69d78afe2ce52b1650ba91a6381f355ff08c1d0e53d9e66bd62fe"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = "UT"
   revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7ffc0983035bc7e297da3688d9fe19d60a420e9c38bef23f845c53788ed6a05e"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:9f28b7e326b8cd1db556678b7ce679cf9bf888647e40922f91d9d40f451f942b"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = "UT"
   revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
 
 [[projects]]
+  digest = "1:772bf4d1907ccb275aaa532ec6cb0d85fc61bd05648af28551590af3ea4e2d53"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4c012f6dcd9546820e378d0bdda4d8fc772cdfea"
 
 [[projects]]
+  digest = "1:f8e1a678a2571e265f4bf91a3e5e32aa6b1474a55cb0ea849750cc177b664d96"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = "UT"
   revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c9c0ba9ea00233c41b91e441cfd490f34b129bbfebcb1858979623bd8de07f72"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "e24f485414aeafb646f6fca458b0bf869c0880a1"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -136,18 +177,29 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = "UT"
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
+  digest = "1:cb130999076da4717267c51235d62b63228c330ad86160255cbe3276de4c9892"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c95af922eae69f190717a0b7148960af8c55a072"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8d9a1b665b338530deef434f168913ba1184f835aa5bfed3a213a14c613bc17e"
+  input-imports = [
+    "github.com/fatih/color",
+    "github.com/golang/glog",
+    "github.com/jinzhu/gorm",
+    "github.com/jinzhu/gorm/dialects/postgres",
+    "github.com/spf13/cobra",
+    "github.com/spf13/viper",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/aquasecurity/kube-bench/check"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -34,8 +35,8 @@ var (
 	pgSQL              bool
 	checkList          string
 	groupList          string
-	masterFile         string
-	nodeFile           string
+	masterFile         = "master.yaml"
+	nodeFile           = "node.yaml"
 	federatedFile      string
 	noResults          bool
 	noSummary          bool
@@ -47,6 +48,14 @@ var RootCmd = &cobra.Command{
 	Use:   os.Args[0],
 	Short: "Run CIS Benchmarks checks against a Kubernetes deployment",
 	Long:  `This tool runs the CIS Kubernetes Benchmark (https://www.cisecurity.org/benchmark/kubernetes/)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if isMaster() {
+			glog.V(1).Info("== Running master checks ==\n")
+			runChecks(check.MASTER)
+		}
+		glog.V(1).Info("== Running node checks ==\n")
+		runChecks(check.NODE)
+	},
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -72,8 +72,9 @@ func ps(proc string) string {
 	return string(out)
 }
 
-// getBinaries finds which of the set of candidate executables are running
-func getBinaries(v *viper.Viper) map[string]string {
+// getBinaries finds which of the set of candidate executables are running.
+// It returns an error if one mandatory executable is not running.
+func getBinaries(v *viper.Viper) (map[string]string, error) {
 	binmap := make(map[string]string)
 
 	for _, component := range v.GetStringSlice("components") {
@@ -87,7 +88,7 @@ func getBinaries(v *viper.Viper) map[string]string {
 		if len(bins) > 0 {
 			bin, err := findExecutable(bins)
 			if err != nil && !optional {
-				exitWithError(fmt.Errorf("need %s executable but none of the candidates are running", component))
+				return nil, fmt.Errorf("need %s executable but none of the candidates are running", component)
 			}
 
 			// Default the executable name that we'll substitute to the name of the component
@@ -101,7 +102,7 @@ func getBinaries(v *viper.Viper) map[string]string {
 		}
 	}
 
-	return binmap
+	return binmap, nil
 }
 
 // getConfigFilePath locates the config files we should be using based on either the specified

--- a/hack/debug.yaml
+++ b/hack/debug.yaml
@@ -1,0 +1,46 @@
+# use this pod with: kubectl run ubuntu -it --pid=host  -- /bin/bash
+# this allows you to debug what is running on the host.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+spec:
+  hostPID: true
+  containers:
+  - name: ubuntu
+    image: ubuntu
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]
+    volumeMounts:
+    - name: var-lib-kubelet
+      mountPath: /var/lib/kubelet
+    - name: etc-systemd
+      mountPath: /etc/systemd
+    - name: etc-kubernetes
+      mountPath: /etc/kubernetes
+      # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+      # You can omit this mount if you specify --version as part of the command.           
+    - name: usr-bin
+      mountPath: /usr/bin
+    - name: kind-bin
+      mountPath: /kind/bin
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  volumes:
+  - name: var-lib-kubelet
+    hostPath:
+      path: "/var/lib/kubelet"
+  - name: etc-systemd
+    hostPath:
+      path: "/etc/systemd"
+  - name: etc-kubernetes
+    hostPath:
+      path: "/etc/kubernetes"
+  - name: usr-bin
+    hostPath:
+      path: "/usr/bin"
+  - name: kind-bin
+    hostPath:
+      path: "/kind/bin"

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-bench
+    spec:
+      hostPID: true
+      containers:
+      - name: kube-bench
+        image: aquasec/kube-bench:${VERSION}
+        command: ["kube-bench"]
+        volumeMounts:
+        - name: var-lib-etcd
+          mountPath: /var/lib/etcd
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: etc-systemd
+          mountPath: /etc/systemd
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+          # You can omit this mount if you specify --version as part of the command.           
+        - name: usr-bin
+          mountPath: /usr/bin
+        - name: kind-bin
+          mountPath: /kind/bin
+      restartPolicy: Never
+      volumes:
+      - name: var-lib-etcd
+        hostPath:
+          path: "/var/lib/etcd"
+      - name: var-lib-kubelet
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: etc-systemd
+        hostPath:
+          path: "/etc/systemd"
+      - name: etc-kubernetes
+        hostPath:
+          path: "/etc/kubernetes"
+      - name: usr-bin
+        hostPath:
+          path: "/usr/bin"
+      - name: kind-bin
+        hostPath:
+          path: "/kind/bin"

--- a/job.yaml
+++ b/job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-bench
+    spec:
+      hostPID: true
+      containers:
+      - name: kube-bench
+        image: aquasec/kube-bench:latest
+        command: ["kube-bench"]
+        volumeMounts:
+        - name: var-lib-etcd
+          mountPath: /var/lib/etcd
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: etc-systemd
+          mountPath: /etc/systemd
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+          # You can omit this mount if you specify --version as part of the command.           
+        - name: usr-bin
+          mountPath: /usr/bin
+      restartPolicy: Never
+      volumes:
+      - name: var-lib-etcd
+        hostPath:
+          path: "/var/lib/etcd"
+      - name: var-lib-kubelet
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: etc-systemd
+        hostPath:
+          path: "/etc/systemd"
+      - name: etc-kubernetes
+        hostPath:
+          path: "/etc/kubernetes"
+      - name: usr-bin
+        hostPath:
+          path: "/usr/bin"

--- a/makefile
+++ b/makefile
@@ -1,7 +1,72 @@
 SOURCES := $(shell find . -name '*.go')
-TARGET_OS := linux
 BINARY := kube-bench
+DOCKER_REGISTRY ?= aquasec
+VERSION ?= $(shell git rev-parse --short=7 HEAD)
+IMAGE_NAME ?= $(DOCKER_REGISTRY)/$(BINARY):$(VERSION)
+TARGET_OS := linux
+BUILD_OS := linux
+uname := $(shell uname -s)
+
+ifneq ($(findstring Microsoft,$(shell uname -r)),)
+	BUILD_OS := windows
+else ifeq ($(uname),Linux)
+	BUILD_OS := linux
+else ifeq ($(uname),Darwin)
+	BUILD_OS := darwin
+endif
+
+# kind cluster name to use
+KIND_PROFILE ?= kube-bench
+KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
+
+build: kube-bench
 
 $(BINARY): $(SOURCES)
 	GOOS=$(TARGET_OS) go build -o $(BINARY) .
 
+# builds the current dev docker version
+build-docker:
+	docker build --build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+             --build-arg VCS_REF=$(shell git rev-parse --short HEAD) \
+             -t $(IMAGE_NAME) .
+
+tests:
+	go test -race -timeout 30s -cover ./cmd ./check
+
+# creates a kind cluster to be used for development.
+HAS_KIND := $(shell command -v kind;)
+kind-test-cluster:
+ifndef HAS_KIND
+	go get -u sigs.k8s.io/kind
+endif
+	@if [ -z $$(kind get clusters | grep $(KIND_PROFILE)) ]; then\
+		echo "Could not find $(KIND_PROFILE) cluster. Creating...";\
+		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.11.3 --wait 5m;\
+	fi
+
+# pushses the current dev version to the kind cluster.
+kind-push:
+	docker save $(IMAGE_NAME) -o kube-bench.tar.gz; \
+	docker cp kube-bench.tar.gz $(KIND_CONTAINER_NAME):/kube-bench.tar.gz; \
+	docker exec $(KIND_CONTAINER_NAME) docker load -i /kube-bench.tar.gz;
+	-rm -f kube-bench.tar.gz
+
+# runs the current version on kind using a job and follow logs
+kind-run: KUBECONFIG = "$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")"
+kind-run: ensure-stern
+	sed "s/\$${VERSION}/$(VERSION)/" ./hack/kind.yaml > ./hack/kind.test.yaml
+	-KUBECONFIG=$(KUBECONFIG) \
+		kubectl delete job kube-bench 
+	KUBECONFIG=$(KUBECONFIG) \
+		kubectl apply -f ./hack/kind.test.yaml
+	KUBECONFIG=$(KUBECONFIG) \
+		stern -l app=kube-bench --container kube-bench
+
+# ensures that stern is installed
+HAS_STERN := $(shell command -v stern;)
+ensure-stern:
+ifndef HAS_STERN
+	curl -LO https://github.com/wercker/stern/releases/download/1.10.0/stern_$(BUILD_OS)_amd64 && \
+		chmod +rx ./stern_$(BUILD_OS)_amd64 && \
+    	mv ./stern_$(BUILD_OS)_amd64 /usr/local/bin/stern
+endif


### PR DESCRIPTION
This adds master node detection and a root command that automatically detect checks to run.
The root command will run node checks and if possible master checks. You can still override checks config files for master and node using respectively `--master-file` and `--node-file`.

The `master` and `node` commands are still supported for backward compatibility.

I've also added some Makefile targets to improve local testing and reflected changes into the documentation.

Closes https://github.com/aquasecurity/kube-bench/issues/72