### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Tests are configured with YAML files, making this tool easy to update as test sp
 
 ## CIS Kubernetes Benchmark support
 
-kube-bench supports the tests for multiple versions of Kubernetes (1.6, 1.7, 1.8, and 1.11) as defined in the CIS Benchmarks 1.0.0, 1.1.0, 1.2.0, and 1.3.0 respectively. It will determine the test set to run based on the Kubernetes version running on the machine.
+kube-bench supports the tests for multiple versions of Kubernetes (1.6, 1.7, 1.8, 1.11, 1.12 and 1.13) as defined in the CIS Benchmarks 1.0.0, 1.1.0, 1.2.0, 1.3.0 and 1.4.0 respectively. It will determine the test set to run based on the Kubernetes version running on the machine.
 
 ## Installation
 


### PR DESCRIPTION
update of CIS_Kubernetes_Benchmark_v1.4.0 for Kubernetes 1.13 reflected in readme.

https://github.com/aquasecurity/kube-bench/pull/226