### PR TITLE
Add ":" as a valid flag-value separator for tests

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -166,6 +166,8 @@ func (c *Check) Run() {
 		i++
 	}
 
+	glog.V(3).Info(out.String())
+
 	finalOutput := c.Tests.execute(out.String())
 	if finalOutput != nil {
 		c.ActualValue = finalOutput.actualResult

--- a/check/data
+++ b/check/data
@@ -158,3 +158,12 @@ groups:
             set: true
 
 
+    - id: 14
+      text: "check that flag some-arg is set to some-val with ':' separator"
+      tests:
+        test_items:
+          - flag: "some-arg"
+            compare:
+              op: eq
+              value: some-val
+            set: true

--- a/check/test.go
+++ b/check/test.go
@@ -68,7 +68,7 @@ func (t *testItem) execute(s string) *testOutput {
 			// --flag
 			// somevalue
 			//pttn := `(` + t.Flag + `)(=)*([^\s,]*) *`
-			pttn := `(` + t.Flag + `)(=)*([^\s]*) *`
+			pttn := `(` + t.Flag + `)(=|: *)*([^\s]*) *`
 			flagRe := regexp.MustCompile(pttn)
 			vals := flagRe.FindStringSubmatch(s)
 

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -110,6 +110,16 @@ func TestTestExecute(t *testing.T) {
 			controls.Groups[0].Checks[13],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=Something ---audit-log-maxage=40",
 		},
+		{
+			// check for ':' as argument-value separator, with space between arg and val
+			controls.Groups[0].Checks[14],
+			"2:45 kube-apiserver some-arg: some-val --admission-control=Something ---audit-log-maxage=40",
+		},
+		{
+			// check for ':' as argument-value separator, with no space between arg and val
+			controls.Groups[0].Checks[14],
+			"2:45 kube-apiserver some-arg:some-val --admission-control=Something ---audit-log-maxage=40",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Adds enhancement #241. This is useful for checking values in YAML (possibly JSON) kubernetes config files.