### PR TITLE
[Issue 225 (enhancement)] Adding repeat option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ vendor
 dist
 .vscode/
 hack/kind.test.yaml
-*.tar.gz
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor
 dist
 .vscode/
 hack/kind.test.yaml
+*.tar.gz
+.DS_Store

--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -366,8 +366,10 @@ groups:
     text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
+      bin_op: or
       test_items:
       - flag: "--service-account-lookup"
+        set: false
         compare:
           op: eq
           value: true
@@ -1168,7 +1170,7 @@ groups:
       Run the below command (based on the file location on your system) on the
       master node. For example, chown root:root /etc/kubernetes/controller-manager.conf
     scored: true
-  
+
   - id: 1.4.19
     text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
     audit: "ls -laR /etc/kubernetes/pki/"
@@ -1181,10 +1183,10 @@ groups:
           value: "root root"
         set: true
     remediation: |
-      Run the below command (based on the file location on your system) on the master node. 
+      Run the below command (based on the file location on your system) on the master node.
       For example, chown -R root:root /etc/kubernetes/pki/
     scored: true
-    
+
   - id: 1.4.20
     text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %n\ %a /etc/kubernetes/pki/*.crt"
@@ -1208,12 +1210,12 @@ groups:
             value: "600"
           set: true
     remediation: |
-      Run the below command (based on the file location on your system) on the master node. 
+      Run the below command (based on the file location on your system) on the master node.
       For example, chmod -R 644 /etc/kubernetes/pki/*.crt
     scored: true
-    
+
   - id: 1.4.21
-    text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored)"
+    text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Scored)"
     audit: "stat -c %n\ %a /etc/kubernetes/pki/*.key"
     type: "manual"
     tests:
@@ -1224,7 +1226,7 @@ groups:
             value: "600"
           set: true
     remediation: |
-      Run the below command (based on the file location on your system) on the master node. 
+      Run the below command (based on the file location on your system) on the master node.
       For example, chmod -R 600 /etc/kubernetes/pki/*.key
     scored: true
 

--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -366,10 +366,7 @@ groups:
     text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
-      bin_op: or
       test_items:
-      - flag: "--service-account-lookup"
-        set: false
       - flag: "--service-account-lookup"
         compare:
           op: eq
@@ -1216,7 +1213,7 @@ groups:
     scored: true
     
   - id: 1.4.21
-    text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Scored)"
+    text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %n\ %a /etc/kubernetes/pki/*.key"
     type: "manual"
     tests:

--- a/cfg/ocp-3.10/master.yaml
+++ b/cfg/ocp-3.10/master.yaml
@@ -1,20 +1,21 @@
 ---
 controls:
-version: 1.6
+version: 3.10
 id: 1
-text: "Master Node Security Configuration"
+text: "Securing the OpenShift Master"
 type: "master"
 groups:
-- id: 1.1
-  text: "API Server"
+
+- id: 1
+  text: "Protecting the API Server"
   checks:
-  - id: 1.1.1
-    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+  - id: 1.1
+    text: "Maintain default behavior for anonymous access"
     type: "skip"
     scored: true
 
-  - id: 1.1.2
-    text: "Ensure that the --basic-auth-file argument is not set (Scored)"
+  - id: 1.2
+    text: "Verify that the basic-auth-file method is not enabled"
     audit: "grep -A2 basic-auth-file /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -26,20 +27,19 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml and
       remove the basic-auth-file entry.
-
       kubernetesMasterConfig:
-        apiServerArguments:
-           basic-auth-file:
-             - /path/to/any/file
+        apiServerArguments:
+           basic-auth-file:
+             - /path/to/any/file
     scored: true
 
-  - id: 1.1.3
-    text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
+  - id: 1.3
+    text: "Insecure Tokens"
     type: "skip"
     scored: true
 
-  - id: 1.1.4
-    text: "Ensure that the --kubelet-https argument is set to true (Scored)"
+  - id: 1.4
+    text: "Secure communications between the API server and master nodes"
     audit: "grep -A4 kubeletClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -72,16 +72,15 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml
       and change it to match the below.
-
       kubeletClientInfo:
-        ca: ca-bundle.crt
-        certFile: master.kubelet-client.crt
-        keyFile: master.kubelet-client.key
-        port: 10250
+        ca: ca-bundle.crt
+        certFile: master.kubelet-client.crt
+        keyFile: master.kubelet-client.key
+        port: 10250
     scored: true
 
-  - id: 1.1.5
-    text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
+  - id: 1.5
+    text: "Prevent insecure bindings"
     audit: "grep -A2 insecure-bind-address /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -90,15 +89,14 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml
       and remove the insecure-bind-address entry.
-
       kubernetesMasterConfig:
-        apiServerArguments:
-           insecure-bind-address:
-           - 127.0.0.1
+        apiServerArguments:
+           insecure-bind-address:
+           - 127.0.0.1
     scored: true
 
-  - id: 1.1.6
-    text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
+  - id: 1.6
+    text: "Prevent insecure port access"
     audit: "grep -A2 insecure-port /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -107,15 +105,14 @@ groups:
     remediation: |
      Edit the kubernetes master config file /etc/origin/master/master-config.yaml
      and remove the insecure-port entry.
-
      kubernetesMasterConfig:
-       apiServerArguments:
-         insecure-port:
-         - 0
+       apiServerArguments:
+         insecure-port:
+         - 0
     scored: true
 
-  - id: 1.1.7
-    text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
+  - id: 1.7
+    text: "Use Secure Ports for API Server Traffic"
     audit: "grep -A2 secure-port /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -131,20 +128,19 @@ groups:
      Edit the kubernetes master config file /etc/origin/master/master-config.yaml
      and either remove the secure-port parameter or set it to a different (non-zero)
      desired port.
-
      kubernetesMasterConfig:
-       apiServerArguments:
-         secure-port:
-         - 8443
+       apiServerArguments:
+         secure-port:
+         - 8443
     scored: true
 
-  - id: 1.1.8
-    text: "Ensure that the --profiling argument is set to false (Scored)"
+  - id: 1.8
+    text: "Do not expose API server profiling data"
     type: "skip"
     scored: true
 
-  - id: 1.1.9
-    text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
+  - id: 1.9
+    text: "Verify repair-malformed-updates argument for API compatibility"
     audit: "grep -A2 repair-malformed-updates /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -161,8 +157,8 @@ groups:
      and remove the repair-malformed-updates entry or set repair-malformed-updates=true.
     scored: true
 
-  - id: 1.1.10
-    text: "Ensure that the admission control plugin AlwaysAdmit is not set (Scored)"
+  - id: 1.10
+    text: "Verify that the AlwaysAdmit admission controller is disabled"
     audit: "grep -A4 AlwaysAdmit /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -171,7 +167,6 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml
       and remove the the entry below.
-
       AlwaysAdmit:
         configuration:
           kind: DefaultAdmissionConfig
@@ -179,8 +174,8 @@ groups:
           disable: false
     scored: true
 
-  - id: 1.1.11
-    text: "Ensure that the admission control plugin AlwaysPullImages is set (Scored)"
+  - id: 1.11
+    text: "Manage the AlwaysPullImages admission controller"
     audit: "grep -A4 AlwaysPullImages /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -192,7 +187,6 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml
       and add the the entry below.
-
       admissionConfig:
         pluginConfig:
           AlwaysPullImages:
@@ -202,18 +196,18 @@ groups:
               disable: false
     scored: true
 
-  - id: 1.1.12
-    text: "Ensure that the admission control plugin DenyEscalatingExec is set (Scored)"
+  - id: 1.12
+    text: "Use Security Context Constraints instead of DenyEscalatingExec admission"
     type: "skip"
     scored: true
 
-  - id: 1.1.13
-    text: "Ensure that the admission control plugin SecurityContextDeny is set (Scored)"
+  - id: 1.13
+    text: "Use Security Context Constraints instead of the SecurityContextDeny admission controller"
     type: "skip"
     scored: true
 
-  - id: 1.1.14
-    text: "Ensure that the admission control plugin NamespaceLifecycle is set (Scored)"
+  - id: 1.14
+    text: "Manage the NamespaceLifecycle admission controller"
     audit: "grep -A4 NamespaceLifecycle /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -222,16 +216,15 @@ groups:
     remediation: |
       Edit the kubernetes master config file /etc/origin/master/master-config.yaml
       and remove the following entry.
-
-      NamespaceLifecycle: 
+      NamespaceLifecycle:
         configuration:
           kind: DefaultAdmissionConfig
           apiVersion: v1
           disable: true
     scored: true
 
-  - id: 1.1.15
-    text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
+  - id: 1.15
+    text: "Configure API server auditing - audit log file path"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -242,24 +235,22 @@ groups:
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml, update the following entry and restart the API server.
-
       auditConfig:
-        auditFilePath: "/var/log/audit-ocp.log"
+        auditFilePath: ""/etc/origin/master/audit-ocp.log""
         enabled: true
-        maximumFileRetentionDays: 10
-        maximumFileSizeMegabytes: 100
+        maximumFileRetentionDays: 30
+        maximumFileSizeMegabytes: 10
         maximumRetainedFiles: 10
-
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.1.16
-    text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
+  - id: 1.16
+    text: "Configure API server auditing - audit log retention"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "maximumFileRetentionDays: 10"
+      - flag: "maximumFileRetentionDays: 30"
         compare:
           op: has
           value: "maximumFileRetentionDays"
@@ -267,20 +258,18 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml,
       update the maximumFileRetentionDays entry and restart the API server.
-
       auditConfig:
-        auditFilePath: "/var/log/audit-ocp.log"
+        auditFilePath: ""/etc/origin/master/audit-ocp.log""
         enabled: true
-        maximumFileRetentionDays: 10
-        maximumFileSizeMegabytes: 100
+        maximumFileRetentionDays: 30
+        maximumFileSizeMegabytes: 10
         maximumRetainedFiles: 10
-
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.1.17
-    text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
+  - id: 1.17
+    text: "Configure API server auditing - audit log backup retention"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -292,24 +281,22 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml, update the maximumRetainedFiles entry,
       set enabled to true and restart the API server.
-
       auditConfig:
-        auditFilePath: "/var/log/audit-ocp.log"
+        auditFilePath: ""/etc/origin/master/audit-ocp.log""
         enabled: true
-        maximumFileRetentionDays: 10
-        maximumFileSizeMegabytes: 100
+        maximumFileRetentionDays: 30
+        maximumFileSizeMegabytes: 10
         maximumRetainedFiles: 10
-
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.1.18
-    text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
+  - id: 1.18
+    text: "Configure audit log file size"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "maximumFileSizeMegabytes: 100"
+      - flag: "maximumFileSizeMegabytes: 30"
         compare:
           op: has
           value: "maximumFileSizeMegabytes"
@@ -317,20 +304,18 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml, update the maximumFileSizeMegabytes entry,
       set enabled to true and restart the API server.
-
       auditConfig:
-        auditFilePath: "/var/log/audit-ocp.log"
+        auditFilePath: ""/etc/origin/master/audit-ocp.log""
         enabled: true
-        maximumFileRetentionDays: 10
-        maximumFileSizeMegabytes: 100
+        maximumFileRetentionDays: 30
+        maximumFileSizeMegabytes: 10
         maximumRetainedFiles: 10
-
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.1.19
-    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+  - id: 1.19
+    text: "Verify that authorization-mode is not set to AlwaysAllow"
     audit: "grep -A1 authorization-mode /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -339,15 +324,14 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and remove the authorization-mode
       entry.
-
       kubernetesMasterConfig:
-        apiServerArguments:
-           authorization-mode:
-             - AllowAll
+        apiServerArguments:
+           authorization-mode:
+             - AllowAll
     scored: true
 
-  - id: 1.1.20
-    text: "Ensure that the --token-auth-file parameter is not set (Scored)"
+  - id: 1.20
+    text: "Verify that the token-auth-file flag is not set"
     audit: "grep token-auth-file /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -356,15 +340,14 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and remove the token-auth-file
       entry under apiserverArguments section.
-
       kubernetesMasterConfig:
-        apiServerArguments:
-           token-auth-file:
-             - /path/to/file
+        apiServerArguments:
+           token-auth-file:
+             - /path/to/file
     scored: true
 
-  - id: 1.1.21
-    text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
+  - id: 1.21
+    text: "Verify the API server certificate authority"
     audit: "grep -A1 kubelet-certificate-authority /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -373,15 +356,14 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and remove the following
       configuration under apiserverArguments section.
-
       kubernetesMasterConfig:
-        apiServerArguments:
-           kubelet-certificat-authority:
-             - /path/to/ca
+        apiServerArguments:
+           kubelet-certificat-authority:
+             - /path/to/ca
     scored: true
 
-  - id: 1.1.22
-    text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Scored)"
+  - id: 1.22
+    text: "Verify the API server client certificate and client key"
     audit: "grep -A4 kubeletClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -399,26 +381,25 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and add the following
       configuration under kubeletClientInfo
-
       kubeletClientInfo:
-        ca: ca-bundle.crt
-        certFile: master.kubelet-client.crt
-        keyFile: master.kubelet-client.key
+        ca: ca-bundle.crt
+        certFile: master.kubelet-client.crt
+        keyFile: master.kubelet-client.key
         port: 10250
     scored: true
 
-  - id: 1.1.23
-    text: "Ensure that the --service-account-lookup argument is set to true"
+  - id: 1.23
+    text: "Verify that the service account lookup flag is not set"
     type: skip
     scored: true
 
-  - id: 1.1.24
-    text: "Ensure that the admission control plugin PodSecurityPolicy is set (Scored)"
+  - id: 1.24
+    text: "Verify the PodSecurityPolicy is disabled to ensure use of SecurityContextConstraints"
     type: "skip"
     scored: true
 
-  - id: 1.1.25
-    text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
+  - id: 1.25
+    text: "Verify that the service account key file argument is not set"
     audit: "grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -434,31 +415,28 @@ groups:
           value: "serviceaccounts.public.key"
         set: true
     remediation: |
-      OpenShift API server does not use the service-account-key-file argument. 
-      Even if value is set in master-config.yaml, it will not be used to verify 
-      service account tokens, as it is in upstream Kubernetes. The ServiceAccount 
-      token authenticator is configured with serviceAccountConfig.publicKeyFiles in 
+      OpenShift API server does not use the service-account-key-file argument.
+      Even if value is set in master-config.yaml, it will not be used to verify
+      service account tokens, as it is in upstream Kubernetes. The ServiceAccount
+      token authenticator is configured with serviceAccountConfig.publicKeyFiles in
       the master-config.yaml. OpenShift does not reuse the apiserver TLS key.
-
-      Edit the Openshift master config file /etc/origin/master/master-config.yaml and set the privateKeyFile 
+      Edit the Openshift master config file /etc/origin/master/master-config.yaml and set the privateKeyFile
       and publicKeyFile configuration under serviceAccountConfig.
-
         serviceAccountConfig:
-          limitSecretReferences: false
-          managedNames:
+          limitSecretReferences: false
+          managedNames:
             - default
-            - builder
-            - deployer
-          masterCA: ca-bundle.crt
-          privateKeyFile: serviceaccounts.private.key
-          publicKeyFiles:
-            - serviceaccounts.public.key
-
+            - builder
+            - deployer
+          masterCA: ca-bundle.crt
+          privateKeyFile: serviceaccounts.private.key
+          publicKeyFiles:
+            - serviceaccounts.public.key
       Verify that privateKeyFile and publicKeyFile exist and set.
     scored: true
 
-  - id: 1.1.26
-    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored)"
+  - id: 1.26
+    text: "Verify the certificate and key used for communication with etcd"
     audit: "grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -474,17 +452,17 @@ groups:
           value: "keyFile: master.etcd-client.key"
         set: true
     remediation: |
-      Edit the Openshift master config file /etc/origin/master/master-config.yaml and set keyFile and certFile 
+      Edit the Openshift master config file /etc/origin/master/master-config.yaml and set keyFile and certFile
       under etcdClientInfo like below.
-      
+
         etcdClientInfo:
-          ca: master.etcd-ca.crt
+          ca: master.etcd-ca.crt
           certFile: master.etcd-client.crt
           keyFile: master.etcd-client.key
     scored: true
 
-  - id: 1.1.27
-    text: "Ensure that the admission control plugin ServiceAccount is set (Scored)"
+  - id: 1.27
+    text: "Verify that the ServiceAccount admission controller is enabled"
     audit: "grep -A4 ServiceAccount /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -499,16 +477,16 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and enable ServiceAccount
       admission control policy.
-      
-        ServiceAccount: 
+
+        ServiceAccount:
           configuration:
             kind: DefaultAdmissionConfig
             apiVersion: v1
             disable: false
     scored: true
 
-  - id: 1.1.28
-    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+  - id: 1.28
+    text: "Verify the certificate and key used to encrypt API server traffic"
     audit: "grep -A7 servingInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -525,10 +503,9 @@ groups:
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and set keyFile and certFile under servingInfo.
-
         servingInfo:
-          bindAddress: 0.0.0.0:8443
-          bindNetwork: tcp4
+          bindAddress: 0.0.0.0:8443
+          bindNetwork: tcp4
           certFile: master.server.crt
           clientCA: ca.crt
           keyFile: master.server.key
@@ -536,22 +513,18 @@ groups:
           requestTimeoutSeconds: 3600
     scored: true
 
-  - id: 1.1.29
-    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
-    audit: "grep -A7 servingInfo /etc/origin/master/master-config.yaml"
+  - id: 1.29
+    text: "Verify that the --client-ca-file argument is not set"
+    audit: "grep client-ca-file /etc/origin/master/master-config.yaml"
     tests:
       test_items:
       - flag: "clientCA: ca.crt"
-        compare:
-          op: has
-          value: "clientCA: ca.crt"
-        set: true
+        set: false
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and set clientCA under servingInfo.
-
         servingInfo:
-          bindAddress: 0.0.0.0:8443
-          bindNetwork: tcp4
+          bindAddress: 0.0.0.0:8443
+          bindNetwork: tcp4
           certFile: master.server.crt
           clientCA: ca.crt
           keyFile: master.server.key
@@ -559,8 +532,8 @@ groups:
           requestTimeoutSeconds: 3600
     scored: true
 
-  - id: 1.1.30
-    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+  - id: 1.30
+    text: "Verify the CA used for communication with etcd"
     audit: "grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -571,20 +544,19 @@ groups:
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and set ca under etcdClientInfo.
-
         etcdClientInfo:
-          ca: master.etcd-ca.crt
+          ca: master.etcd-ca.crt
           certFile: master.etcd-client.crt
           keyFile: master.etcd-client.key
     scored: true
 
-  - id: 1.1.31
-    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+  - id: 1.31
+    text: "Verify that the authorization-mode argument is not set"
     type: "skip"
     scored: true
 
-  - id: 1.1.32
-    text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
+  - id: 1.32
+    text: "Verify that the NodeRestriction admission controller is enabled"
     audit: "grep -A4 NodeRestriction /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -598,7 +570,6 @@ groups:
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and enable NodeRestriction ca under etcdClientInfo.
-
         NodeRestriction:
           configuration:
             kind: DefaultAdmissionConfig
@@ -606,8 +577,8 @@ groups:
             disable: false
     scored: true
 
-  - id: 1.1.33
-    text: "Ensure that the --experimental-encryption-provider-config argument is set as appropriate (Scored)"
+  - id: 1.33
+    text: "Configure encryption of data at rest in etcd datastore"
     audit: "grep -A1 experimental-encryption-provider-config /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -617,12 +588,12 @@ groups:
           value: "experimental-encryption-provider-config:"
         set: true
     remediation: |
-      Follow the instructions in the documentation to configure encryption. 
+      Follow the instructions in the documentation to configure encryption.
       https://docs.openshift.com/container-platform/3.10/admin_guide/encrypting_data.html
     scored: true
 
-  - id: 1.1.34
-    text: "Ensure that the encryption provider is set to aescbc (Scored)"
+  - id: 1.34
+    text: "Set the encryption provider to aescbc for etcd data at rest"
     audit: "grep -A1 experimental-encryption-provider-config /etc/origin/master/master-config.yaml | sed -n '2p' | awk '{ print $2 }' | xargs grep -A1 providers"
     tests:
       test_items:
@@ -636,8 +607,8 @@ groups:
       See https://docs.openshift.com/container-platform/3.10/admin_guide/encrypting_data.html.
     scored: true
 
-  - id: 1.1.35
-    text: "Ensure that the admission control policy is set to EventRateLimit (Scored)"
+  - id: 1.35
+    text: "Enable the EventRateLimit plugin"
     audit: "grep -A4 EventRateLimit /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -648,11 +619,11 @@ groups:
         set: true
     remediation: |
       Follow the documentation to enable the EventRateLimit plugin.
-      https://docs.openshift.com/container-platform/3.10/architecture/additional_concepts/admission_controllers.html#admission-controllers-general-admission-rules 
+      https://docs.openshift.com/container-platform/3.10/architecture/additional_concepts/admission_controllers.html#admission-controllers-general-admission-rules
     scored: true
 
-  - id: 1.1.36
-    text: "Ensure that the AdvancedAuditing argument is not set to false (Scored)"
+  - id: 1.36
+    text: "Configure advanced auditing"
     audit: "grep AdvancedAuditing /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -666,63 +637,60 @@ groups:
         set: false
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and enable AdvancedAuditing,
-
       kubernetesMasterConfig:
-        apiServerArguments:
+        apiServerArguments:
           feature-gates:
             - AdvancedAuditing=true
     scored: true
 
   # Review 1.1.37 in Aquasec shared doc, the tests are net zero.
-  - id: 1.1.37
-    text: "Ensure that the --request-timeout argument is set as appropriate (Scored)"
+  - id: 1.37
+    text: "Adjust the request timeout argument for your cluster resources"
     audit: "grep request-timeout /etc/origin/master/master-config.yaml"
     type: manual
     remediation: |
-      change the request-timeout value in the  /etc/origin/master/master-config.yaml
+      change the request-timeout value in the  /etc/origin/master/master-config.yaml
     scored: true
 
 
-- id: 1.2
+- id: 2
   text: "Scheduler"
   checks:
-  - id: 1.2.1
-    text: "Ensure that the --profiling argument is set to false (Scored)"
+  - id: 2.1
+    text: "Verify that Scheduler profiling is not exposed to the web"
     type: "skip"
     scored: true
 
 
-- id: 1.3
+- id: 3
   text: "Controller Manager"
   checks:
-  - id: 1.3.1
-    text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
+  - id: 3.1
+    text: "Adjust the terminated-pod-gc-threshold argument as needed"
     audit: "grep terminated-pod-gc-threshold -A1 /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "true"
+      - flag: "terminated-pod-gc-threshold:"
         compare:
           op: has
-          value: "true"
+          value: "12500"
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml  and enable terminated-pod-gc-threshold.
-
         kubernetesMasterConfig:
-          controllerArguments:
-             terminated-pod-gc-threshold:
-             - true
-
+          controllerArguments:
+             terminated-pod-gc-threshold:
+             - true
       Enabling the "terminated-pod-gc-threshold" settings is optional.
     scored: true
 
-  - id: 1.3.2
-    text: "Ensure that the --profiling argument is set to false (Scored)"
+  - id: 3.2
+    text: "Verify that Controller profiling is not exposed to the web"
     type: "skip"
     scored: true
 
-  - id: 1.3.3
-    text: "Ensure that the --use-service-account-credentials argument is set to true (Scored)"
+  - id: 3.3
+    text: "Verify that the --use-service-account-credentials argument is set to true"
     audit: "grep -A2 use-service-account-credentials /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -737,16 +705,15 @@ groups:
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and set use-service-account-credentials
       to true under controllerArguments section.
-
       kubernetesMasterConfig:
-        controllerArguments:
-           use-service-account-credentials:
-             - true
+        controllerArguments:
+           use-service-account-credentials:
+             - true
     scored: true
 
-  # Review 1.3.4
-  - id: 1.3.4
-    text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
+  # Review 3.4
+  - id: 3.4
+    text: "Verify that the --service-account-private-key-file argument is set as appropriate"
     audit: |
       grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml | grep privateKeyFile;
       grep -A2 service-account-private-key-file /etc/origin/master/master-config.yaml
@@ -763,9 +730,9 @@ groups:
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and remove service-account-private-key-file
     scored: true
 
-  # Review 1.3.5
-  - id: 1.3.5
-    text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
+  # Review 3.5
+  - id: 3.5
+    text: "Verify that the --root-ca-file argument is set as appropriate"
     audit: "/bin/sh -c 'grep root-ca-file /etc/origin/master/master-config.yaml; grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml'"
     tests:
       bin_op: and
@@ -783,20 +750,20 @@ groups:
           set: true
     remediation:
       Reset to OpenShift defaults OpenShift starts kube-controller-manager with
-      root-ca-file=/etc/origin/master/ca-bundle.crt by default.  OpenShift Advanced
+      root-ca-file=/etc/origin/master/ca-bundle.crt by default.  OpenShift Advanced
       Installation creates this certificate authority and configuration without any
       configuration required.
 
       https://docs.openshift.com/container-platform/3.10/admin_guide/service_accounts.html"
     scored: true
 
-  - id: 1.3.6
-    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+  - id: 3.6
+    text: "Verify that Security Context Constraints are applied to Your Pods and Containers"
     type: "skip"
     scored: false
 
-  - id: 1.3.7
-    text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
+  - id: 3.7
+    text: "Manage certificate rotation"
     audit: "grep -B3 RotateKubeletServerCertificate=true /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -812,38 +779,26 @@ groups:
     scored: true
 
 
-- id: 1.4
+- id: 4
   text: "Configuration Files"
   checks:
-  - id: 1.4.1
-    text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.1
+    text: "Verify the OpenShift default permissions for the API server pod specification file"
     audit: "stat -c %a /etc/origin/node/pods/apiserver.yaml"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
-        compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
-        set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
     remediation: |
       Run the below command.
-
-      chmod 644 /etc/origin/node/pods/apiserver.yaml
+      chmod 600 /etc/origin/node/pods/apiserver.yaml
     scored: true
 
-  - id: 1.4.2
-    text: "Ensure that the API server pod specification file ownership is set to root:root (Scored)"
+  - id: 4.2
+    text: "Verify the OpenShift default file ownership for the API server pod specification file"
     audit: "stat -c %U:%G /etc/origin/node/pods/apiserver.yaml"
     tests:
       test_items:
@@ -854,39 +809,26 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown root:root /etc/origin/node/pods/apiserver.yaml
     scored: true
 
-  - id: 1.4.3
-    text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.3
+    text: "Verify the OpenShift default file permissions for the controller manager pod specification file"
     audit: "stat -c %a /etc/origin/node/pods/controller.yaml"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
-        compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
-        set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
     remediation: |
       Run the below command on the master node.
-
-      chmod 644 /etc/origin/node/pods/controllermanager.yaml
+      chmod 600 /etc/origin/node/pods/controller.yaml
     scored: true
 
-  - id: 1.4.4
-    text: "Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
+  - id: 4.4
+    text: "Verify the OpenShift default ownership for the controller manager pod specification file"
     audit: "stat -c %U:%G /etc/origin/node/pods/controller.yaml"
     tests:
       test_items:
@@ -897,40 +839,27 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/controllermanager.yaml
+      chown root:root /etc/origin/node/pods/controller.yaml
     scored: true
 
-  - id: 1.4.5
-    text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
-    audit: "stat -c %a /etc/origin/node/pods/apiserver.yaml"
+  - id: 4.5
+    text: "Verify the OpenShift default permissions for the scheduler pod specification file"
+    audit: "stat -c %a /etc/origin/node/pods/controller.yaml"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
-        compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
-        set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
     remediation: |
       Run the below command.
-
-      chmod 644 /etc/origin/node/pods/apiserver.yaml
+      chmod 600 stat -c %a /etc/origin/node/pods/controller.yaml
     scored: true
 
-  - id: 1.4.6
-    text: "Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
-    audit: "stat -c %U:%G /etc/origin/node/pods/apiserver.yaml"
+  - id: 4.6
+    text: "Verify the scheduler pod specification file ownership set by OpenShift"
+    audit: "stat -c %u:%g /etc/origin/node/pods/controller.yaml"
     tests:
       test_items:
       - flag: "root:root"
@@ -940,39 +869,26 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/apiserver.yaml
+      chown root:root /etc/origin/node/pods/controller.yaml
     scored: true
 
-  - id: 1.4.7
-    text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.7
+    text: "Verify the OpenShift default etcd pod specification file permissions"
     audit: "stat -c %a /etc/origin/node/pods/etcd.yaml"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
-        compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
-        set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
     remediation: |
       Run the below command.
-
-      chmod 644 /etc/origin/node/pods/etcd.yaml
+      chmod 600 /etc/origin/node/pods/etcd.yaml
     scored: true
 
-  - id: 1.4.8
-    text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
+  - id: 4.8
+    text: "Verify the OpenShift default etcd pod specification file ownership"
     audit: "stat -c %U:%G /etc/origin/node/pods/etcd.yaml"
     tests:
       test_items:
@@ -983,13 +899,12 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown root:root /etc/origin/node/pods/etcd.yaml
     scored: true
 
-  - id: 1.4.9
-    text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Scored)"
-    audit: "stat -c %a /etc/origin/openvswitch/"
+  - id: 4.9
+    text: "Verify the default OpenShift Container Network Interface file permissions"
+    audit: "stat -c %a /etc/origin/openvswitch/ /etc/cni/net.d/"
     tests:
       bin_op: or
       test_items:
@@ -1010,13 +925,12 @@ groups:
         set: true
     remediation: |
       Run the below command.
-
-      chmod 644 /etc/origin/openvswitch/
+      chmod 644 -R /etc/origin/openvswitch/ /etc/cni/net.d/
     scored: true
 
-  - id: 1.4.10
-    text: "Ensure that the Container Network Interface file ownership is set to root:root (Scored)"
-    audit: "stat -c %U:%G /etc/origin/openvswitch/"
+  - id: 4.10
+    text: "Verify the default OpenShift Container Network Interface file ownership"
+    audit: "stat -c %U:%G /etc/origin/openvswitch/ /etc/cni/net.d/"
     tests:
       test_items:
       - flag: "root:root"
@@ -1026,12 +940,11 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
-      chown root:root /etc/origin/openvswitch/
+      chown root:root /etc/origin/openvswitch/ /etc/cni/net.d/
     scored: true
 
-  - id: 1.4.11
-    text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive(Scored)"
+  - id: 4.11
+    text: "Verify the default OpenShift etcd data directory permissions"
     audit: "stat -c %a /var/lib/etcd"
     tests:
       test_items:
@@ -1048,8 +961,8 @@ groups:
       chmod 700 /var/lib/etcd
     scored: true
 
-  - id: 1.4.12
-    text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+  - id: 4.12
+    text: "Verify the default OpenShift etcd data directory ownership"
     audit: "stat -c %U:%G /var/lib/etcd"
     tests:
       test_items:
@@ -1060,12 +973,11 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown etcd:etcd /var/lib/etcd
     scored: true
 
-  - id: 1.4.13
-    text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.13
+    text: "Verify the default OpenShift admin.conf file permissions"
     audit: "stat -c %a /etc/origin/master/admin.kubeconfig"
     tests:
       bin_op: or
@@ -1087,12 +999,11 @@ groups:
         set: true
     remediation: |
       Run the below command.
-
       chmod 644 /etc/origin/master/admin.kubeconfig"
     scored: true
 
-  - id: 1.4.14
-    text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
+  - id: 4.14
+    text: "Verify the default OpenShift admin.conf file ownership"
     audit: "stat -c %U:%G /etc/origin/master/admin.kubeconfig"
     tests:
       test_items:
@@ -1103,12 +1014,11 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown root:root /etc/origin/master/admin.kubeconfig
     scored: true
 
-  - id: 1.4.15
-    text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.15
+    text: "Verify the default OpenShift scheduler.conf file permissions"
     audit: "stat -c %a /etc/origin/master/openshift-master.kubeconfig"
     tests:
       bin_op: or
@@ -1130,12 +1040,11 @@ groups:
         set: true
     remediation: |
       Run the below command.
-
       chmod 644 /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 1.4.16
-    text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
+  - id: 4.16
+    text: "Verify the default OpenShift scheduler.conf file ownership"
     audit: "stat -c %U:%G /etc/origin/master/openshift-master.kubeconfig"
     tests:
       test_items:
@@ -1146,12 +1055,11 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown root:root /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 1.4.17
-    text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
+  - id: 4.17
+    text: "Verify the default Openshift controller-manager.conf file permissions"
     audit: "stat -c %a /etc/origin/master/openshift-master.kubeconfig"
     tests:
       bin_op: or
@@ -1173,11 +1081,10 @@ groups:
         set: true
     remediation: |
       Run the below command.
-
       chmod 644 /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 1.4.18
+  - id: 4.18
     text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/master/openshift-master.kubeconfig"
     tests:
@@ -1189,16 +1096,15 @@ groups:
         set: true
     remediation: |
       Run the below command on the master node.
-
       chown root:root /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
 
-- id: 1.5
+- id: 5
   text: "Etcd"
   checks:
-  - id: 1.5.1
-    text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
+  - id: 5.1
+    text: "Verify the default OpenShift cert-file and key-file configuration"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_CERT_FILE=/etc/etcd/server.crt /proc/1/environ; /usr/local/bin/master-exec etcd etcd grep etcd_key_file=/etc/etcd/server.key /proc/1/environ; grep ETCD_CERT_FILE=/etc/etcd/server.crt /etc/etcd/etcd.conf; grep ETCD_KEY_FILE=/etc/etcd/server.key /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1222,8 +1128,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.2
-    text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
+  - id: 5.2
+    text: "Verify the default OpenShift setting for the client-cert-auth argument"
     audit: "/bin/sh -c'/usr/local/bin/master-exec etcd etcd grep ETCD_CLIENT_CERT_AUTH=true /proc/1/environ; grep ETCD_CLIENT_CERT_AUTH /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1242,8 +1148,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.3
-    text: "Ensure that the --auto-tls argument is not set to true (Scored)"
+  - id: 5.3
+    text: "Verify the OpenShift default values for etcd_auto_tls"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_AUTO_TLS /proc/1/environ; grep ETCD_AUTO_TLS /etc/etcd/etcd.conf'"
     tests:
       bin_op: or
@@ -1262,8 +1168,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.4
-    text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
+  - id: 5.4
+    text: "Verify the OpenShift default peer-cert-file and peer-key-file arguments for etcd"
     audit: "/bin/sh -c'/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_CERT_FILE=/etc/etcd/peer.crt /proc/1/environ; /usr/local/bin/master-exec etcd etcd grep ETCD_PEER_KEY_FILE=/etc/etcd/peer.key /proc/1/environ; grep ETCD_PEER_CERT_FILE /etc/etcd/etcd.conf; grep ETCD_PEER_KEY_FILE /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1287,8 +1193,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.5
-    text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
+  - id: 5.5
+    text: "Verify the OpenShift default configuration for the peer-client-cert-auth"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_CLIENT_CERT_AUTH=true /proc/1/environ; grep ETCD_PEER_CLIENT_CERT_AUTH /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1307,8 +1213,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.6
-    text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
+  - id: 5.6
+    text: "Verify the OpenShift default configuration for the peer-auto-tls argument"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_AUTO_TLS /proc/1/environ; grep ETCD_PEER_AUTO_TLS /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1327,18 +1233,18 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 1.5.7
-    text: "Ensure that the --wal-dir argument is set as appropriate Scored)"
+  - id: 5.7
+    text: "Optionally modify the wal-dir argument"
     type: "skip"
     scored: true
 
-  - id: 1.5.8
-    text: "Ensure that the --max-wals argument is set to 0 (Scored)"
+  - id: 5.8
+    text: "Optionally modify the max-wals argument"
     type: "skip"
     scored: true
 
-  - id: 1.5.9
-    text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
+  - id: 5.9
+    text: "Verify the OpenShift default configuration for the etcd Certificate Authority"
     audit: "openssl x509 -in /etc/origin/master/master.etcd-ca.crt -subject -issuer -noout | sed 's/@/ /'"
     tests:
       test_items:
@@ -1352,149 +1258,128 @@ groups:
     scored: false
 
 
-- id: 1.6
+- id: 6
   text: "General Security Primitives"
   checks:
-  - id: 1.6.1
-    text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+  - id: 6.1
+    text: "Ensure that the cluster-admin role is only used where required"
     type: "manual"
     remediation: |
       Review users, groups, serviceaccounts bound to cluster-admin:
       oc get clusterrolebindings | grep cluster-admin
-
       Review users and groups bound to cluster-admin and decide whether they require
       such access. Consider creating least-privilege roles for users and service accounts
     scored: false
 
-  - id: 1.6.2
-    text: "Create Pod Security Policies for your cluster (Not Scored)"
+  - id: 6.2
+    text: "Verify Security Context Constraints as in use"
     type: "manual"
     remediation: |
       Review Security Context Constraints:
       oc get scc
-
       Use OpenShift's Security Context Constraint feature, which has been contributed
       to Kubernetes as Pod Security Policies. PSPs are still beta in Kubernetes 1.10.
       OpenShift ships with two SCCs: restricted and privileged.
-
       The two default SCCs will be created when the master is started. The restricted
       SCC is granted to all authenticated users by default.
-
        https://docs.openshift.com/container-platform/3.10/admin_guide/manage_scc.html"
     scored: false
 
-  - id: 1.6.3
-    text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+  - id: 6.3
+    text: "Use OpenShift projects to maintain boundaries between resources"
     type: "manual"
     remediation: |
       Review projects:
       oc get projects
     scored: false
 
-  - id: 1.6.4
-    text: "Create network segmentation using Network Policies (Not Scored)"
+  - id: 6.4
+    text: "Create network segmentation using the Multi-tenant plugin or Network Policies"
     type: "manual"
     remediation: |
       Verify on masters the plugin being used:
       grep networkPluginName /etc/origin/master/master-config.yaml
-
       OpenShift provides multi-tenant networking isolation (using Open vSwich and
       vXLAN), to segregate network traffic between containers belonging to different
       tenants (users or applications) while running on a shared cluster. Red Hat also
       works with 3rd-party SDN vendors to provide the same level of capabilities
       integrated with OpenShift. OpenShift SDN is included a part of OpenShift
       subscription.
-
       OpenShift supports Kubernetes NetworkPolicy. Administrator must configure
       NetworkPolicies if desired.
-
       https://docs.openshift.com/container-platform/3.10/architecture/networking/sdn.html#architecture-additional-concepts-sdn
-
       Ansible Inventory variable: os_sdn_network_plugin_name:
       https://docs.openshift.com/container-platform/3.10/install/configuring_inventory_file.html
     scored: false
 
-  - id: 1.6.5
-    text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Not Scored)"
+  - id: 6.5
+    text: "Enable seccomp and configure custom Security Context Constraints"
     type: "manual"
     remediation: |
       Verify SCCs that have been configured with seccomp:
       oc get scc -ocustom-columns=NAME:.metadata.name,SECCOMP-PROFILES:.seccompProfiles
-
       OpenShift does not enable seccomp by default. To configure seccomp profiles that
       are applied to pods run by the SCC, follow the instructions in the
       documentation:
-
       https://docs.openshift.com/container-platform/3.9/admin_guide/seccomp.html#admin-guide-seccomp
     scored: false
 
-  - id: 1.6.6
-    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+  - id: 6.6
+    text: "Review Security Context Constraints"
     type: "manual"
     remediation: |
       Review SCCs:
       oc describe scc
-
       Use OpenShift's Security Context Constraint feature, which has been contributed
       to Kubernetes as Pod Security Policies. PSPs are still beta in Kubernetes 1.10.
-
       OpenShift ships with two SCCs: restricted and privileged. The two default SCCs
       will be created when the master is started. The restricted SCC is granted to
       all authenticated users by default.
-
       All pods are run under the restricted SCC by default. Running a pod under any
       other SCC requires an account with cluster admin capabilities to grant access
       for the service account.
-
       SecurityContextConstraints limit what securityContext is applied to pods and
       containers.
-
       https://docs.openshift.com/container-platform/3.10/admin_guide/manage_scc.html
     scored: false
 
-  - id: 1.6.7
-    text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+  - id: 6.7
+    text: "Manage Image Provenance using ImagePolicyWebhook admission controller"
     type: "manual"
     remediation: |
       Review imagePolicyConfig in /etc/origin/master/master-config.yaml.
     scored: false
 
-  - id: 1.6.8
-    text: "Configure Network policies as appropriate (Not Scored)"
+  - id: 6.8
+    text: "Configure Network policies as appropriate"
     type: "manual"
     remediation: |
       If ovs-networkplugin is used, review network policies:
       oc get networkpolicies
-
       OpenShift supports Kubernetes NetworkPolicy via ovs-networkpolicy plugin.
       If choosing ovs-multitenant plugin, each namespace is isolated in its own
       netnamespace by default.
     scored: false
 
-  - id: 1.6.9
-    text: "Place compensating controls in the form of PSP and RBAC for privileged containers usage (Not Scored)"
+  - id: 6.9
+    text: "Use Security Context Constraints as compensating controls for privileged containers"
     type: "manual"
     remediation: |
       1) Determine all sccs allowing privileged containers:
          oc get scc -ocustom-columns=NAME:.metadata.name,ALLOWS_PRIVILEGED:.allowPrivilegedContainer
       2) Review users and groups assigned to sccs allowing priviliged containers:
          oc describe sccs <from (1)>
-
       Use OpenShift's Security Context Constraint feature, which has been contributed
       to Kubernetes as Pod Security Policies. PSPs are still beta in Kubernetes 1.10.
-
       OpenShift ships with two SCCs: restricted and privileged. The two default SCCs
       will be created when the master is started. The restricted SCC is granted to all
       authenticated users by default.
-
       Similar scenarios are documented in the SCC
       documentation, which outlines granting SCC access to specific serviceaccounts.
       Administrators may create least-restrictive SCCs based on individual container
       needs.
-
       For example, if a container only requires running as the root user, the anyuid
       SCC can be used, which will not expose additional access granted by running
       privileged containers.
-
       https://docs.openshift.com/container-platform/3.10/admin_guide/manage_scc.html
     scored: false

--- a/cfg/ocp-3.10/master.yaml
+++ b/cfg/ocp-3.10/master.yaml
@@ -1,21 +1,20 @@
 ---
 controls:
-version: 3.10
+version: 1.6
 id: 1
-text: "Securing the OpenShift Master"
+text: "Master Node Security Configuration"
 type: "master"
 groups:
-
-- id: 1
-  text: "Protecting the API Server"
+- id: 1.1
+  text: "API Server"
   checks:
-  - id: 1.1
-    text: "Maintain default behavior for anonymous access"
+  - id: 1.1.1
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.2
-    text: "Verify that the basic-auth-file method is not enabled"
+  - id: 1.1.2
+    text: "Ensure that the --basic-auth-file argument is not set (Scored)"
     audit: "grep -A2 basic-auth-file /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -34,13 +33,13 @@ groups:
              - /path/to/any/file
     scored: true
 
-  - id: 1.3
-    text: "Insecure Tokens"
+  - id: 1.1.3
+    text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.4
-    text: "Secure communications between the API server and master nodes"
+  - id: 1.1.4
+    text: "Ensure that the --kubelet-https argument is set to true (Scored)"
     audit: "grep -A4 kubeletClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -81,8 +80,8 @@ groups:
         port: 10250
     scored: true
 
-  - id: 1.5
-    text: "Prevent insecure bindings"
+  - id: 1.1.5
+    text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
     audit: "grep -A2 insecure-bind-address /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -98,8 +97,8 @@ groups:
            - 127.0.0.1
     scored: true
 
-  - id: 1.6
-    text: "Prevent insecure port access"
+  - id: 1.1.6
+    text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
     audit: "grep -A2 insecure-port /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -115,8 +114,8 @@ groups:
          - 0
     scored: true
 
-  - id: 1.7
-    text: "Use Secure Ports for API Server Traffic"
+  - id: 1.1.7
+    text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
     audit: "grep -A2 secure-port /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -139,13 +138,13 @@ groups:
          - 8443
     scored: true
 
-  - id: 1.8
-    text: "Do not expose API server profiling data"
+  - id: 1.1.8
+    text: "Ensure that the --profiling argument is set to false (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.9
-    text: "Verify repair-malformed-updates argument for API compatibility"
+  - id: 1.1.9
+    text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
     audit: "grep -A2 repair-malformed-updates /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -162,8 +161,8 @@ groups:
      and remove the repair-malformed-updates entry or set repair-malformed-updates=true.
     scored: true
 
-  - id: 1.10
-    text: "Verify that the AlwaysAdmit admission controller is disabled"
+  - id: 1.1.10
+    text: "Ensure that the admission control plugin AlwaysAdmit is not set (Scored)"
     audit: "grep -A4 AlwaysAdmit /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -180,8 +179,8 @@ groups:
           disable: false
     scored: true
 
-  - id: 1.11
-    text: "Manage the AlwaysPullImages admission controller"
+  - id: 1.1.11
+    text: "Ensure that the admission control plugin AlwaysPullImages is set (Scored)"
     audit: "grep -A4 AlwaysPullImages /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -203,18 +202,18 @@ groups:
               disable: false
     scored: true
 
-  - id: 1.12
-    text: "Use Security Context Constraints instead of DenyEscalatingExec admission"
+  - id: 1.1.12
+    text: "Ensure that the admission control plugin DenyEscalatingExec is set (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.13
-    text: "Use Security Context Constraints instead of the SecurityContextDeny admission controller"
+  - id: 1.1.13
+    text: "Ensure that the admission control plugin SecurityContextDeny is set (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.14
-    text: "Manage the NamespaceLifecycle admission controller"
+  - id: 1.1.14
+    text: "Ensure that the admission control plugin NamespaceLifecycle is set (Scored)"
     audit: "grep -A4 NamespaceLifecycle /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -231,8 +230,8 @@ groups:
           disable: true
     scored: true
 
-  - id: 1.15
-    text: "Configure API server auditing - audit log file path"
+  - id: 1.1.15
+    text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -245,22 +244,22 @@ groups:
       Edit the Openshift master config file /etc/origin/master/master-config.yaml, update the following entry and restart the API server.
 
       auditConfig:
-        auditFilePath: ""/etc/origin/master/audit-ocp.log""
+        auditFilePath: "/var/log/audit-ocp.log"
         enabled: true
-        maximumFileRetentionDays: 30
-        maximumFileSizeMegabytes: 10
+        maximumFileRetentionDays: 10
+        maximumFileSizeMegabytes: 100
         maximumRetainedFiles: 10
 
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.16
-    text: "Configure API server auditing - audit log retention"
+  - id: 1.1.16
+    text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "maximumFileRetentionDays: 30"
+      - flag: "maximumFileRetentionDays: 10"
         compare:
           op: has
           value: "maximumFileRetentionDays"
@@ -270,18 +269,18 @@ groups:
       update the maximumFileRetentionDays entry and restart the API server.
 
       auditConfig:
-        auditFilePath: ""/etc/origin/master/audit-ocp.log""
+        auditFilePath: "/var/log/audit-ocp.log"
         enabled: true
-        maximumFileRetentionDays: 30
-        maximumFileSizeMegabytes: 10
+        maximumFileRetentionDays: 10
+        maximumFileSizeMegabytes: 100
         maximumRetainedFiles: 10
 
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.17
-    text: "Configure API server auditing - audit log backup retention"
+  - id: 1.1.17
+    text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -295,22 +294,22 @@ groups:
       set enabled to true and restart the API server.
 
       auditConfig:
-        auditFilePath: ""/etc/origin/master/audit-ocp.log""
+        auditFilePath: "/var/log/audit-ocp.log"
         enabled: true
-        maximumFileRetentionDays: 30
-        maximumFileSizeMegabytes: 10
+        maximumFileRetentionDays: 10
+        maximumFileSizeMegabytes: 100
         maximumRetainedFiles: 10
 
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.18
-    text: "Configure audit log file size"
+  - id: 1.1.18
+    text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
     audit: "grep -A5 auditConfig /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "maximumFileSizeMegabytes: 30"
+      - flag: "maximumFileSizeMegabytes: 100"
         compare:
           op: has
           value: "maximumFileSizeMegabytes"
@@ -320,18 +319,18 @@ groups:
       set enabled to true and restart the API server.
 
       auditConfig:
-        auditFilePath: ""/etc/origin/master/audit-ocp.log""
+        auditFilePath: "/var/log/audit-ocp.log"
         enabled: true
-        maximumFileRetentionDays: 30
-        maximumFileSizeMegabytes: 10
+        maximumFileRetentionDays: 10
+        maximumFileSizeMegabytes: 100
         maximumRetainedFiles: 10
 
       Make the same changes in the inventory/ansible variables so the changes are not
       lost when an upgrade occurs.
     scored: true
 
-  - id: 1.19
-    text: "Verify that authorization-mode is not set to AlwaysAllow"
+  - id: 1.1.19
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
     audit: "grep -A1 authorization-mode /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -347,8 +346,8 @@ groups:
              - AllowAll
     scored: true
 
-  - id: 1.20
-    text: "Verify that the token-auth-file flag is not set"
+  - id: 1.1.20
+    text: "Ensure that the --token-auth-file parameter is not set (Scored)"
     audit: "grep token-auth-file /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -364,8 +363,8 @@ groups:
              - /path/to/file
     scored: true
 
-  - id: 1.21
-    text: "Verify the API server certificate authority"
+  - id: 1.1.21
+    text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
     audit: "grep -A1 kubelet-certificate-authority /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -381,8 +380,8 @@ groups:
              - /path/to/ca
     scored: true
 
-  - id: 1.22
-    text: "Verify the API server client certificate and client key"
+  - id: 1.1.22
+    text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Scored)"
     audit: "grep -A4 kubeletClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -408,18 +407,18 @@ groups:
         port: 10250
     scored: true
 
-  - id: 1.23
-    text: "Verify that the service account lookup flag is not set"
+  - id: 1.1.23
+    text: "Ensure that the --service-account-lookup argument is set to true"
     type: skip
     scored: true
 
-  - id: 1.24
-    text: "Verify the PodSecurityPolicy is disabled to ensure use of SecurityContextConstraints"
+  - id: 1.1.24
+    text: "Ensure that the admission control plugin PodSecurityPolicy is set (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.25
-    text: "Verify that the service account key file argument is not set"
+  - id: 1.1.25
+    text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
     audit: "grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -458,8 +457,8 @@ groups:
       Verify that privateKeyFile and publicKeyFile exist and set.
     scored: true
 
-  - id: 1.26
-    text: "Verify the certificate and key used for communication with etcd"
+  - id: 1.1.26
+    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored)"
     audit: "grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -484,8 +483,8 @@ groups:
           keyFile: master.etcd-client.key
     scored: true
 
-  - id: 1.27
-    text: "Verify that the ServiceAccount admission controller is enabled"
+  - id: 1.1.27
+    text: "Ensure that the admission control plugin ServiceAccount is set (Scored)"
     audit: "grep -A4 ServiceAccount /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -508,8 +507,8 @@ groups:
             disable: false
     scored: true
 
-  - id: 1.28
-    text: "Verify the certificate and key used to encrypt API server traffic"
+  - id: 1.1.28
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
     audit: "grep -A7 servingInfo /etc/origin/master/master-config.yaml"
     tests:
       bin_op: and
@@ -537,13 +536,16 @@ groups:
           requestTimeoutSeconds: 3600
     scored: true
 
-  - id: 1.29
-    text: "Verify that the --client-ca-file argument is not set"
-    audit: "grep client-ca-file /etc/origin/master/master-config.yaml"
+  - id: 1.1.29
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+    audit: "grep -A7 servingInfo /etc/origin/master/master-config.yaml"
     tests:
       test_items:
       - flag: "clientCA: ca.crt"
-        set: false
+        compare:
+          op: has
+          value: "clientCA: ca.crt"
+        set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and set clientCA under servingInfo.
 
@@ -557,8 +559,8 @@ groups:
           requestTimeoutSeconds: 3600
     scored: true
 
-  - id: 1.30
-    text: "Verify the CA used for communication with etcd"
+  - id: 1.1.30
+    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
     audit: "grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -576,13 +578,13 @@ groups:
           keyFile: master.etcd-client.key
     scored: true
 
-  - id: 1.31
-    text: "Verify that the authorization-mode argument is not set"
+  - id: 1.1.31
+    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
     type: "skip"
     scored: true
 
-  - id: 1.32
-    text: "Verify that the NodeRestriction admission controller is enabled"
+  - id: 1.1.32
+    text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
     audit: "grep -A4 NodeRestriction /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -604,8 +606,8 @@ groups:
             disable: false
     scored: true
 
-  - id: 1.33
-    text: "Configure encryption of data at rest in etcd datastore"
+  - id: 1.1.33
+    text: "Ensure that the --experimental-encryption-provider-config argument is set as appropriate (Scored)"
     audit: "grep -A1 experimental-encryption-provider-config /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -619,8 +621,8 @@ groups:
       https://docs.openshift.com/container-platform/3.10/admin_guide/encrypting_data.html
     scored: true
 
-  - id: 1.34
-    text: "Set the encryption provider to aescbc for etcd data at rest"
+  - id: 1.1.34
+    text: "Ensure that the encryption provider is set to aescbc (Scored)"
     audit: "grep -A1 experimental-encryption-provider-config /etc/origin/master/master-config.yaml | sed -n '2p' | awk '{ print $2 }' | xargs grep -A1 providers"
     tests:
       test_items:
@@ -634,8 +636,8 @@ groups:
       See https://docs.openshift.com/container-platform/3.10/admin_guide/encrypting_data.html.
     scored: true
 
-  - id: 1.35
-    text: "Enable the EventRateLimit plugin"
+  - id: 1.1.35
+    text: "Ensure that the admission control policy is set to EventRateLimit (Scored)"
     audit: "grep -A4 EventRateLimit /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -649,8 +651,8 @@ groups:
       https://docs.openshift.com/container-platform/3.10/architecture/additional_concepts/admission_controllers.html#admission-controllers-general-admission-rules 
     scored: true
 
-  - id: 1.36
-    text: "Configure advanced auditing"
+  - id: 1.1.36
+    text: "Ensure that the AdvancedAuditing argument is not set to false (Scored)"
     audit: "grep AdvancedAuditing /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -672,8 +674,8 @@ groups:
     scored: true
 
   # Review 1.1.37 in Aquasec shared doc, the tests are net zero.
-  - id: 1.37
-    text: "Adjust the request timeout argument for your cluster resources"
+  - id: 1.1.37
+    text: "Ensure that the --request-timeout argument is set as appropriate (Scored)"
     audit: "grep request-timeout /etc/origin/master/master-config.yaml"
     type: manual
     remediation: |
@@ -681,27 +683,27 @@ groups:
     scored: true
 
 
-- id: 2
+- id: 1.2
   text: "Scheduler"
   checks:
-  - id: 2.1
-    text: "Verify that Scheduler profiling is not exposed to the web"
+  - id: 1.2.1
+    text: "Ensure that the --profiling argument is set to false (Scored)"
     type: "skip"
     scored: true
 
 
-- id: 3
+- id: 1.3
   text: "Controller Manager"
   checks:
-  - id: 3.1
-    text: "Adjust the terminated-pod-gc-threshold argument as needed"
+  - id: 1.3.1
+    text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
     audit: "grep terminated-pod-gc-threshold -A1 /etc/origin/master/master-config.yaml"
     tests:
       test_items:
-      - flag: "terminated-pod-gc-threshold:"
+      - flag: "true"
         compare:
           op: has
-          value: "12500"
+          value: "true"
         set: true
     remediation: |
       Edit the Openshift master config file /etc/origin/master/master-config.yaml  and enable terminated-pod-gc-threshold.
@@ -714,13 +716,13 @@ groups:
       Enabling the "terminated-pod-gc-threshold" settings is optional.
     scored: true
 
-  - id: 3.2
-    text: "Verify that Controller profiling is not exposed to the web"
+  - id: 1.3.2
+    text: "Ensure that the --profiling argument is set to false (Scored)"
     type: "skip"
     scored: true
 
-  - id: 3.3
-    text: "Verify that the --use-service-account-credentials argument is set to true"
+  - id: 1.3.3
+    text: "Ensure that the --use-service-account-credentials argument is set to true (Scored)"
     audit: "grep -A2 use-service-account-credentials /etc/origin/master/master-config.yaml"
     tests:
       bin_op: or
@@ -742,9 +744,9 @@ groups:
              - true
     scored: true
 
-  # Review 3.4
-  - id: 3.4
-    text: "Verify that the --service-account-private-key-file argument is set as appropriate"
+  # Review 1.3.4
+  - id: 1.3.4
+    text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
     audit: |
       grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml | grep privateKeyFile;
       grep -A2 service-account-private-key-file /etc/origin/master/master-config.yaml
@@ -761,9 +763,9 @@ groups:
       Edit the Openshift master config file /etc/origin/master/master-config.yaml and remove service-account-private-key-file
     scored: true
 
-  # Review 3.5
-  - id: 3.5
-    text: "Verify that the --root-ca-file argument is set as appropriate"
+  # Review 1.3.5
+  - id: 1.3.5
+    text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
     audit: "/bin/sh -c 'grep root-ca-file /etc/origin/master/master-config.yaml; grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml'"
     tests:
       bin_op: and
@@ -788,13 +790,13 @@ groups:
       https://docs.openshift.com/container-platform/3.10/admin_guide/service_accounts.html"
     scored: true
 
-  - id: 3.6
-    text: "Verify that Security Context Constraints are applied to Your Pods and Containers"
+  - id: 1.3.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
     type: "skip"
     scored: false
 
-  - id: 3.7
-    text: "Manage certificate rotation"
+  - id: 1.3.7
+    text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
     audit: "grep -B3 RotateKubeletServerCertificate=true /etc/origin/master/master-config.yaml"
     tests:
       test_items:
@@ -810,140 +812,12 @@ groups:
     scored: true
 
 
-- id: 4
+- id: 1.4
   text: "Configuration Files"
   checks:
-  - id: 4.1
-    text: "Verify the OpenShift default permissions for the API server pod specification file"
+  - id: 1.4.1
+    text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/node/pods/apiserver.yaml"
-    tests:      
-      test_items:
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true
-    remediation: |
-      Run the below command.
-
-      chmod 600 /etc/origin/node/pods/apiserver.yaml
-    scored: true
-
-  - id: 4.2
-    text: "Verify the OpenShift default file ownership for the API server pod specification file"
-    audit: "stat -c %U:%G /etc/origin/node/pods/apiserver.yaml"
-    tests:
-      test_items:
-      - flag: "root:root"
-        compare:
-          op: eq
-          value: "root:root"
-        set: true
-    remediation: |
-      Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/apiserver.yaml
-    scored: true
-
-  - id: 4.3
-    text: "Verify the OpenShift default file permissions for the controller manager pod specification file"
-    audit: "stat -c %a /etc/origin/node/pods/controller.yaml"
-    tests:      
-      test_items:
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true
-    remediation: |
-      Run the below command on the master node.
-
-      chmod 600 /etc/origin/node/pods/controller.yaml
-    scored: true
-
-  - id: 4.4
-    text: "Verify the OpenShift default ownership for the controller manager pod specification file"
-    audit: "stat -c %U:%G /etc/origin/node/pods/controller.yaml"
-    tests:
-      test_items:
-      - flag: "root:root"
-        compare:
-          op: eq
-          value: "root:root"
-        set: true
-    remediation: |
-      Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/controller.yaml
-    scored: true
-
-  - id: 4.5
-    text: "Verify the OpenShift default permissions for the scheduler pod specification file"
-    audit: "stat -c %a /etc/origin/node/pods/controller.yaml"
-    tests:      
-      test_items:
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true
-    remediation: |
-      Run the below command.
-
-      chmod 600 stat -c %a /etc/origin/node/pods/controller.yaml
-    scored: true
-
-  - id: 4.6
-    text: "Verify the scheduler pod specification file ownership set by OpenShift"
-    audit: "stat -c %u:%g /etc/origin/node/pods/controller.yaml"
-    tests:
-      test_items:
-      - flag: "root:root"
-        compare:
-          op: eq
-          value: "root:root"
-        set: true
-    remediation: |
-      Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/controller.yaml
-    scored: true
-
-  - id: 4.7
-    text: "Verify the OpenShift default etcd pod specification file permissions"
-    audit: "stat -c %a /etc/origin/node/pods/etcd.yaml"
-    tests:      
-      test_items:
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true
-    remediation: |
-      Run the below command.
-
-      chmod 600 /etc/origin/node/pods/etcd.yaml
-    scored: true
-
-  - id: 4.8
-    text: "Verify the OpenShift default etcd pod specification file ownership"
-    audit: "stat -c %U:%G /etc/origin/node/pods/etcd.yaml"
-    tests:
-      test_items:
-      - flag: "root:root"
-        compare:
-          op: eq
-          value: "root:root"
-        set: true
-    remediation: |
-      Run the below command on the master node.
-
-      chown root:root /etc/origin/node/pods/etcd.yaml
-    scored: true
-
-  - id: 4.9
-    text: "Verify the default OpenShift Container Network Interface file permissions"
-    audit: "stat -c %a /etc/origin/openvswitch/ /etc/cni/net.d/"
     tests:
       bin_op: or
       test_items:
@@ -965,12 +839,12 @@ groups:
     remediation: |
       Run the below command.
 
-      chmod 644 -R /etc/origin/openvswitch/ /etc/cni/net.d/
+      chmod 644 /etc/origin/node/pods/apiserver.yaml
     scored: true
 
-  - id: 4.10
-    text: "Verify the default OpenShift Container Network Interface file ownership"
-    audit: "stat -c %U:%G /etc/origin/openvswitch/ /etc/cni/net.d/"
+  - id: 1.4.2
+    text: "Ensure that the API server pod specification file ownership is set to root:root (Scored)"
+    audit: "stat -c %U:%G /etc/origin/node/pods/apiserver.yaml"
     tests:
       test_items:
       - flag: "root:root"
@@ -981,11 +855,183 @@ groups:
     remediation: |
       Run the below command on the master node.
 
-      chown root:root /etc/origin/openvswitch/ /etc/cni/net.d/
+      chown root:root /etc/origin/node/pods/apiserver.yaml
     scored: true
 
-  - id: 4.11
-    text: "Verify the default OpenShift etcd data directory permissions"
+  - id: 1.4.3
+    text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Scored)"
+    audit: "stat -c %a /etc/origin/node/pods/controller.yaml"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command on the master node.
+
+      chmod 644 /etc/origin/node/pods/controllermanager.yaml
+    scored: true
+
+  - id: 1.4.4
+    text: "Ensure that the controller manager pod specification file ownership is set to root:root (Scored)"
+    audit: "stat -c %U:%G /etc/origin/node/pods/controller.yaml"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command on the master node.
+
+      chown root:root /etc/origin/node/pods/controllermanager.yaml
+    scored: true
+
+  - id: 1.4.5
+    text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Scored)"
+    audit: "stat -c %a /etc/origin/node/pods/apiserver.yaml"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command.
+
+      chmod 644 /etc/origin/node/pods/apiserver.yaml
+    scored: true
+
+  - id: 1.4.6
+    text: "Ensure that the scheduler pod specification file ownership is set to root:root (Scored)"
+    audit: "stat -c %U:%G /etc/origin/node/pods/apiserver.yaml"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command on the master node.
+
+      chown root:root /etc/origin/node/pods/apiserver.yaml
+    scored: true
+
+  - id: 1.4.7
+    text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
+    audit: "stat -c %a /etc/origin/node/pods/etcd.yaml"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command.
+
+      chmod 644 /etc/origin/node/pods/etcd.yaml
+    scored: true
+
+  - id: 1.4.8
+    text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
+    audit: "stat -c %U:%G /etc/origin/node/pods/etcd.yaml"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command on the master node.
+
+      chown root:root /etc/origin/node/pods/etcd.yaml
+    scored: true
+
+  - id: 1.4.9
+    text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Scored)"
+    audit: "stat -c %a /etc/origin/openvswitch/"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command.
+
+      chmod 644 /etc/origin/openvswitch/
+    scored: true
+
+  - id: 1.4.10
+    text: "Ensure that the Container Network Interface file ownership is set to root:root (Scored)"
+    audit: "stat -c %U:%G /etc/origin/openvswitch/"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command on the master node.
+
+      chown root:root /etc/origin/openvswitch/
+    scored: true
+
+  - id: 1.4.11
+    text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive(Scored)"
     audit: "stat -c %a /var/lib/etcd"
     tests:
       test_items:
@@ -1002,8 +1048,8 @@ groups:
       chmod 700 /var/lib/etcd
     scored: true
 
-  - id: 4.12
-    text: "Verify the default OpenShift etcd data directory ownership"
+  - id: 1.4.12
+    text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
     audit: "stat -c %U:%G /var/lib/etcd"
     tests:
       test_items:
@@ -1018,8 +1064,8 @@ groups:
       chown etcd:etcd /var/lib/etcd
     scored: true
 
-  - id: 4.13
-    text: "Verify the default OpenShift admin.conf file permissions"
+  - id: 1.4.13
+    text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/master/admin.kubeconfig"
     tests:
       bin_op: or
@@ -1045,8 +1091,8 @@ groups:
       chmod 644 /etc/origin/master/admin.kubeconfig"
     scored: true
 
-  - id: 4.14
-    text: "Verify the default OpenShift admin.conf file ownership"
+  - id: 1.4.14
+    text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/master/admin.kubeconfig"
     tests:
       test_items:
@@ -1061,8 +1107,8 @@ groups:
       chown root:root /etc/origin/master/admin.kubeconfig
     scored: true
 
-  - id: 4.15
-    text: "Verify the default OpenShift scheduler.conf file permissions"
+  - id: 1.4.15
+    text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/master/openshift-master.kubeconfig"
     tests:
       bin_op: or
@@ -1088,8 +1134,8 @@ groups:
       chmod 644 /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 4.16
-    text: "Verify the default OpenShift scheduler.conf file ownership"
+  - id: 1.4.16
+    text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/master/openshift-master.kubeconfig"
     tests:
       test_items:
@@ -1104,8 +1150,8 @@ groups:
       chown root:root /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 4.17
-    text: "Verify the default Openshift controller-manager.conf file permissions"
+  - id: 1.4.17
+    text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/master/openshift-master.kubeconfig"
     tests:
       bin_op: or
@@ -1131,7 +1177,7 @@ groups:
       chmod 644 /etc/origin/master/openshift-master.kubeconfig
     scored: true
 
-  - id: 4.18
+  - id: 1.4.18
     text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/master/openshift-master.kubeconfig"
     tests:
@@ -1148,11 +1194,11 @@ groups:
     scored: true
 
 
-- id: 5
+- id: 1.5
   text: "Etcd"
   checks:
-  - id: 5.1
-    text: "Verify the default OpenShift cert-file and key-file configuration"
+  - id: 1.5.1
+    text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_CERT_FILE=/etc/etcd/server.crt /proc/1/environ; /usr/local/bin/master-exec etcd etcd grep etcd_key_file=/etc/etcd/server.key /proc/1/environ; grep ETCD_CERT_FILE=/etc/etcd/server.crt /etc/etcd/etcd.conf; grep ETCD_KEY_FILE=/etc/etcd/server.key /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1176,8 +1222,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.2
-    text: "Verify the default OpenShift setting for the client-cert-auth argument"
+  - id: 1.5.2
+    text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
     audit: "/bin/sh -c'/usr/local/bin/master-exec etcd etcd grep ETCD_CLIENT_CERT_AUTH=true /proc/1/environ; grep ETCD_CLIENT_CERT_AUTH /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1196,8 +1242,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.3
-    text: "Verify the OpenShift default values for etcd_auto_tls"
+  - id: 1.5.3
+    text: "Ensure that the --auto-tls argument is not set to true (Scored)"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_AUTO_TLS /proc/1/environ; grep ETCD_AUTO_TLS /etc/etcd/etcd.conf'"
     tests:
       bin_op: or
@@ -1216,8 +1262,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.4
-    text: "Verify the OpenShift default peer-cert-file and peer-key-file arguments for etcd"
+  - id: 1.5.4
+    text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
     audit: "/bin/sh -c'/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_CERT_FILE=/etc/etcd/peer.crt /proc/1/environ; /usr/local/bin/master-exec etcd etcd grep ETCD_PEER_KEY_FILE=/etc/etcd/peer.key /proc/1/environ; grep ETCD_PEER_CERT_FILE /etc/etcd/etcd.conf; grep ETCD_PEER_KEY_FILE /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1241,8 +1287,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.5
-    text: "Verify the OpenShift default configuration for the peer-client-cert-auth"
+  - id: 1.5.5
+    text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_CLIENT_CERT_AUTH=true /proc/1/environ; grep ETCD_PEER_CLIENT_CERT_AUTH /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1261,8 +1307,8 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.6
-    text: "Verify the OpenShift default configuration for the peer-auto-tls argument"
+  - id: 1.5.6
+    text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
     audit: "/bin/sh -c '/usr/local/bin/master-exec etcd etcd grep ETCD_PEER_AUTO_TLS /proc/1/environ; grep ETCD_PEER_AUTO_TLS /etc/etcd/etcd.conf'"
     tests:
       bin_op: and
@@ -1281,18 +1327,18 @@ groups:
       Reset to the OpenShift default configuration.
     scored: true
 
-  - id: 5.7
-    text: "Optionally modify the wal-dir argument"
+  - id: 1.5.7
+    text: "Ensure that the --wal-dir argument is set as appropriate Scored)"
     type: "skip"
     scored: true
 
-  - id: 5.8
-    text: "Optionally modify the max-wals argument"
+  - id: 1.5.8
+    text: "Ensure that the --max-wals argument is set to 0 (Scored)"
     type: "skip"
     scored: true
 
-  - id: 5.9
-    text: "Verify the OpenShift default configuration for the etcd Certificate Authority"
+  - id: 1.5.9
+    text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
     audit: "openssl x509 -in /etc/origin/master/master.etcd-ca.crt -subject -issuer -noout | sed 's/@/ /'"
     tests:
       test_items:
@@ -1306,11 +1352,11 @@ groups:
     scored: false
 
 
-- id: 6
+- id: 1.6
   text: "General Security Primitives"
   checks:
-  - id: 6.1
-    text: "Ensure that the cluster-admin role is only used where required"
+  - id: 1.6.1
+    text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
     type: "manual"
     remediation: |
       Review users, groups, serviceaccounts bound to cluster-admin:
@@ -1320,8 +1366,8 @@ groups:
       such access. Consider creating least-privilege roles for users and service accounts
     scored: false
 
-  - id: 6.2
-    text: "Verify Security Context Constraints as in use"
+  - id: 1.6.2
+    text: "Create Pod Security Policies for your cluster (Not Scored)"
     type: "manual"
     remediation: |
       Review Security Context Constraints:
@@ -1337,16 +1383,16 @@ groups:
        https://docs.openshift.com/container-platform/3.10/admin_guide/manage_scc.html"
     scored: false
 
-  - id: 6.3
-    text: "Use OpenShift projects to maintain boundaries between resources"
+  - id: 1.6.3
+    text: "Create administrative boundaries between resources using namespaces (Not Scored)"
     type: "manual"
     remediation: |
       Review projects:
       oc get projects
     scored: false
 
-  - id: 6.4
-    text: "Create network segmentation using the Multi-tenant plugin or Network Policies"
+  - id: 1.6.4
+    text: "Create network segmentation using Network Policies (Not Scored)"
     type: "manual"
     remediation: |
       Verify on masters the plugin being used:
@@ -1368,8 +1414,8 @@ groups:
       https://docs.openshift.com/container-platform/3.10/install/configuring_inventory_file.html
     scored: false
 
-  - id: 6.5
-    text: "Enable seccomp and configure custom Security Context Constraints"
+  - id: 1.6.5
+    text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Not Scored)"
     type: "manual"
     remediation: |
       Verify SCCs that have been configured with seccomp:
@@ -1382,8 +1428,8 @@ groups:
       https://docs.openshift.com/container-platform/3.9/admin_guide/seccomp.html#admin-guide-seccomp
     scored: false
 
-  - id: 6.6
-    text: "Review Security Context Constraints"
+  - id: 1.6.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
     type: "manual"
     remediation: |
       Review SCCs:
@@ -1406,15 +1452,15 @@ groups:
       https://docs.openshift.com/container-platform/3.10/admin_guide/manage_scc.html
     scored: false
 
-  - id: 6.7
-    text: "Manage Image Provenance using ImagePolicyWebhook admission controller"
+  - id: 1.6.7
+    text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
     type: "manual"
     remediation: |
       Review imagePolicyConfig in /etc/origin/master/master-config.yaml.
     scored: false
 
-  - id: 6.8
-    text: "Configure Network policies as appropriate"
+  - id: 1.6.8
+    text: "Configure Network policies as appropriate (Not Scored)"
     type: "manual"
     remediation: |
       If ovs-networkplugin is used, review network policies:
@@ -1425,8 +1471,8 @@ groups:
       netnamespace by default.
     scored: false
 
-  - id: 6.9
-    text: "Use Security Context Constraints as compensating controls for privileged containers"
+  - id: 1.6.9
+    text: "Place compensating controls in the form of PSP and RBAC for privileged containers usage (Not Scored)"
     type: "manual"
     remediation: |
       1) Determine all sccs allowing privileged containers:

--- a/cfg/ocp-3.10/node.yaml
+++ b/cfg/ocp-3.10/node.yaml
@@ -4,21 +4,21 @@ id: 2
 text: "Worker Node Security Configuration"
 type: "node"
 groups:
-- id: 7
+- id: 2.1
   text: "Kubelet"
   checks:
-  - id: 7.1
-    text: "Use Security Context Constraints to manage privileged containers as needed"
+  - id: 2.1.1
+    text: "Ensure that the --allow-privileged argument is set to false (Scored)"
     type: "skip"
     scored: true
 
-  - id: 7.2
-    text: "Ensure anonymous-auth is not disabled"
+  - id: 2.1.2
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
     type: "skip"
     scored: true
 
-  - id: 7.3
-    text: "Verify that the --authorization-mode argument is set to WebHook"
+  - id: 2.1.3
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
     audit: "grep -A1 authorization-mode /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -35,8 +35,8 @@ groups:
       kubeletArguments in /etc/origin/node/node-config.yaml or set it to "Webhook".
     scored: true
 
-  - id: 7.4
-    text: "Verify the OpenShift default for the client-ca-file argument"
+  - id: 2.1.4
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
     audit: "grep -A1 client-ca-file /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -51,8 +51,8 @@ groups:
       The config file does not have this defined in kubeletArgument, but in PodManifestConfig.
     scored: true
 
-  - id: 7.5
-    text: "Verify the OpenShift default setting for the read-only-port argument"
+  - id: 2.1.5
+    text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
     audit: "grep -A1 read-only-port /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -68,15 +68,15 @@ groups:
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and removed so that the OpenShift default is applied.
     scored: true
 
-  - id: 7.6
-    text: "Adjust the streaming-connection-idle-timeout argument"
+  - id: 2.1.6
+    text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
     audit: "grep -A1 streaming-connection-idle-timeout /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
       test_items:
       - flag: "streaming-connection-idle-timeout"
         set: false
-      - flag: "5m"
+      - flag: "0"
         set: false
     remediation: |
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and set the streaming-connection-timeout
@@ -87,13 +87,13 @@ groups:
            - "5m"
     scored: true
 
-  - id: 7.7
-    text: "Verify the OpenShift defaults for the protect-kernel-defaults argument"
+  - id: 2.1.7
+    text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
     type: "skip"
     scored: true
 
-  - id: 7.8
-    text: "Verify the OpenShift default value of true for the make-iptables-util-chains argument"
+  - id: 2.1.8
+    text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
     audit: "grep -A1 make-iptables-util-chains /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -110,8 +110,8 @@ groups:
       default value of true. 
     scored: true
 
-  - id: 7.9
-    text: "Verify that the --keep-terminated-pod-volumes argument is set to false"
+    id: 2.1.9
+    text: "Ensure that the --keep-terminated-pod-volumeskeep-terminated-pod-volumes argument is set to false (Scored)"
     audit: "grep -A1 keep-terminated-pod-volumes /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -124,13 +124,13 @@ groups:
       Reset to the OpenShift defaults
     scored: true
 
-  - id: 7.10
-    text: "Verify the OpenShift defaults for the hostname-override argument"
+  - id: 2.1.10
+    text: "Ensure that the --hostname-override argument is not set (Scored)"
     type: "skip"
     scored: true
 
-  - id: 7.11
-    text: "Set the --event-qps argument to 0"
+  - id: 2.1.11
+    text: "Ensure that the --event-qps argument is set to 0 (Scored)"
     audit: "grep -A1 event-qps /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -147,8 +147,8 @@ groups:
       the kubeletArguments section of.
     scored: true
 
-  - id: 7.12
-    text: "Verify the OpenShift cert-dir flag for HTTPS traffic"
+  - id: 2.1.12
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
     audit: "grep -A1 cert-dir /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -161,8 +161,8 @@ groups:
       Reset to the OpenShift default values.
     scored: true
 
-  - id: 7.13
-    text: "Verify the OpenShift default of 0 for the cadvisor-port argument"
+  - id: 2.1.13
+    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
     audit: "grep -A1 cadvisor-port /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -179,8 +179,8 @@ groups:
       if it is set in the  kubeletArguments section.
     scored: true
 
-  - id: 7.14
-    text: "Verify that the RotateKubeletClientCertificate argument is set to true"
+  - id: 2.1.14
+    text: "Ensure that the RotateKubeletClientCertificate argument is not set to false (Scored)"
     audit: "grep -B1 RotateKubeletClientCertificate=true /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -193,8 +193,8 @@ groups:
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and set RotateKubeletClientCertificate to true.
     scored: true
 
-  - id: 7.15
-    text: "Verify that the RotateKubeletServerCertificate argument is set to true"
+  - id: 2.1.15
+    text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
     audit: "grep -B1 RotateKubeletServerCertificate=true /etc/origin/node/node-config.yaml"
     test:
       test_items:
@@ -208,11 +208,11 @@ groups:
     scored: true
 
 
-- id: 8
+- id: 2.2
   text: "Configuration Files"
   checks:
-  - id: 8.1
-    text: "Verify the OpenShift default permissions for the kubelet.conf file"
+  - id: 2.2.1
+    text: "Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a  /etc/origin/node/node.kubeconfig"
     tests:
       bin_op: or
@@ -237,8 +237,8 @@ groups:
       chmod 644 /etc/origin/node/node.kubeconfig
     scored: true
 
-  - id: 8.2
-    text: "Verify the kubeconfig file ownership of root:root"
+  - id: 2.2.2
+    text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/node/node.kubeconfig"
     tests:
       test_items:
@@ -252,8 +252,8 @@ groups:
         chown root:root /etc/origin/node/node.kubeconfig
       scored: true
 
-  - id: 8.3
-    text: "Verify the kubelet service file permissions of 644"
+  - id: 2.2.3
+    text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/systemd/system/atomic-openshift-node.service"
     tests:
       bin_op: or
@@ -278,8 +278,8 @@ groups:
       chmod 644 /etc/systemd/system/atomic-openshift-node.service
     scored: true
 
-  - id: 8.4
-    text: "Verify the kubelet service file ownership of root:root"
+  - id: 2.2.4
+    text: "Ensure that the kubelet service file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/systemd/system/atomic-openshift-node.service"
     tests:
       test_items:
@@ -293,8 +293,8 @@ groups:
         chown root:root /etc/systemd/system/atomic-openshift-node.service
       scored: true
 
-  - id: 8.5
-    text: "Verify the OpenShift default permissions for the proxy kubeconfig file"
+  - id: 2.2.5
+    text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/node/node.kubeconfig"
     tests:
       bin_op: or
@@ -319,8 +319,8 @@ groups:
       chmod 644 /etc/origin/node/node.kubeconfig
     scored: true
 
-  - id: 8.6
-    text: "Verify the proxy kubeconfig file ownership of root:root"
+  - id: 2.2.6
+    text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/node/node.kubeconfig"
     tests:
       test_items:
@@ -334,8 +334,8 @@ groups:
         chown root:root /etc/origin/node/node.kubeconfig
       scored: true
 
-  - id: 8.7
-    text: "Verify the OpenShift default permissions for the certificate authorities file."
+  - id: 2.2.7
+    text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
     audit: "stat -c %a /etc/origin/node/client-ca.crt"
     tests:
       bin_op: or
@@ -360,8 +360,8 @@ groups:
       chmod 644 /etc/origin/node/client-ca.crt
     scored: true
 
-  - id: 8.8
-    text: "Verify the client certificate authorities file ownership of root:root"
+  - id: 2.2.8
+    text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
     audit: "stat -c %U:%G /etc/origin/node/client-ca.crt"
     tests:
       test_items:

--- a/cfg/ocp-3.10/node.yaml
+++ b/cfg/ocp-3.10/node.yaml
@@ -4,21 +4,21 @@ id: 2
 text: "Worker Node Security Configuration"
 type: "node"
 groups:
-- id: 2.1
+- id: 7
   text: "Kubelet"
   checks:
-  - id: 2.1.1
-    text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+  - id: 7.1
+    text: "Use Security Context Constraints to manage privileged containers as needed"
     type: "skip"
     scored: true
 
-  - id: 2.1.2
-    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+  - id: 7.2
+    text: "Ensure anonymous-auth is not disabled"
     type: "skip"
     scored: true
 
-  - id: 2.1.3
-    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+  - id: 7.3
+    text: "Verify that the --authorization-mode argument is set to WebHook"
     audit: "grep -A1 authorization-mode /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -35,8 +35,8 @@ groups:
       kubeletArguments in /etc/origin/node/node-config.yaml or set it to "Webhook".
     scored: true
 
-  - id: 2.1.4
-    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+  - id: 7.4
+    text: "Verify the OpenShift default for the client-ca-file argument"
     audit: "grep -A1 client-ca-file /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -45,14 +45,13 @@ groups:
     remediation: |
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and remove any configuration returned by the following:
       grep -A1 client-ca-file /etc/origin/node/node-config.yaml
-
-      Reset to the OpenShift default. 
+      Reset to the OpenShift default.
       See https://github.com/openshift/openshift-ansible/blob/release-3.10/roles/openshift_node_group/templates/node-config.yaml.j2#L65
       The config file does not have this defined in kubeletArgument, but in PodManifestConfig.
     scored: true
 
-  - id: 2.1.5
-    text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
+  - id: 7.5
+    text: "Verify the OpenShift default setting for the read-only-port argument"
     audit: "grep -A1 read-only-port /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -68,32 +67,32 @@ groups:
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and removed so that the OpenShift default is applied.
     scored: true
 
-  - id: 2.1.6
-    text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
+  - id: 7.6
+    text: "Adjust the streaming-connection-idle-timeout argument"
     audit: "grep -A1 streaming-connection-idle-timeout /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
       test_items:
       - flag: "streaming-connection-idle-timeout"
         set: false
-      - flag: "0"
+      - flag: "5m"
         set: false
     remediation: |
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and set the streaming-connection-timeout
       value like the following in node-config.yaml.
-      
+
       kubeletArguments:
-        streaming-connection-idle-timeout:
-           - "5m"
+        streaming-connection-idle-timeout:
+           - "5m"
     scored: true
 
-  - id: 2.1.7
-    text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
+  - id: 7.7
+    text: "Verify the OpenShift defaults for the protect-kernel-defaults argument"
     type: "skip"
     scored: true
 
-  - id: 2.1.8
-    text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
+  - id: 7.8
+    text: "Verify the OpenShift default value of true for the make-iptables-util-chains argument"
     audit: "grep -A1 make-iptables-util-chains /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -107,11 +106,11 @@ groups:
         set: true
     remediation: |
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and reset make-iptables-util-chains to the OpenShift
-      default value of true. 
+      default value of true.
     scored: true
 
-    id: 2.1.9
-    text: "Ensure that the --keep-terminated-pod-volumeskeep-terminated-pod-volumes argument is set to false (Scored)"
+  - id: 7.9
+    text: "Verify that the --keep-terminated-pod-volumes argument is set to false"
     audit: "grep -A1 keep-terminated-pod-volumes /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -124,13 +123,13 @@ groups:
       Reset to the OpenShift defaults
     scored: true
 
-  - id: 2.1.10
-    text: "Ensure that the --hostname-override argument is not set (Scored)"
+  - id: 7.10
+    text: "Verify the OpenShift defaults for the hostname-override argument"
     type: "skip"
     scored: true
 
-  - id: 2.1.11
-    text: "Ensure that the --event-qps argument is set to 0 (Scored)"
+  - id: 7.11
+    text: "Set the --event-qps argument to 0"
     audit: "grep -A1 event-qps /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -147,8 +146,8 @@ groups:
       the kubeletArguments section of.
     scored: true
 
-  - id: 2.1.12
-    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+  - id: 7.12
+    text: "Verify the OpenShift cert-dir flag for HTTPS traffic"
     audit: "grep -A1 cert-dir /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -161,8 +160,8 @@ groups:
       Reset to the OpenShift default values.
     scored: true
 
-  - id: 2.1.13
-    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+  - id: 7.13
+    text: "Verify the OpenShift default of 0 for the cadvisor-port argument"
     audit: "grep -A1 cadvisor-port /etc/origin/node/node-config.yaml"
     tests:
       bin_op: or
@@ -175,12 +174,12 @@ groups:
           value: "0"
         set: true
     remediation: |
-      Edit the Openshift node config file /etc/origin/node/node-config.yaml and remove the cadvisor-port flag 
+      Edit the Openshift node config file /etc/origin/node/node-config.yaml and remove the cadvisor-port flag
       if it is set in the  kubeletArguments section.
     scored: true
 
-  - id: 2.1.14
-    text: "Ensure that the RotateKubeletClientCertificate argument is not set to false (Scored)"
+  - id: 7.14
+    text: "Verify that the RotateKubeletClientCertificate argument is set to true"
     audit: "grep -B1 RotateKubeletClientCertificate=true /etc/origin/node/node-config.yaml"
     tests:
       test_items:
@@ -193,8 +192,8 @@ groups:
       Edit the Openshift node config file /etc/origin/node/node-config.yaml and set RotateKubeletClientCertificate to true.
     scored: true
 
-  - id: 2.1.15
-    text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
+  - id: 7.15
+    text: "Verify that the RotateKubeletServerCertificate argument is set to true"
     audit: "grep -B1 RotateKubeletServerCertificate=true /etc/origin/node/node-config.yaml"
     test:
       test_items:
@@ -208,11 +207,11 @@ groups:
     scored: true
 
 
-- id: 2.2
+- id: 8
   text: "Configuration Files"
   checks:
-  - id: 2.2.1
-    text: "Ensure that the kubelet.conf file permissions are set to 644 or more restrictive (Scored)"
+  - id: 8.1
+    text: "Verify the OpenShift default permissions for the kubelet.conf file"
     audit: "stat -c %a  /etc/origin/node/node.kubeconfig"
     tests:
       bin_op: or
@@ -237,8 +236,8 @@ groups:
       chmod 644 /etc/origin/node/node.kubeconfig
     scored: true
 
-  - id: 2.2.2
-    text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
+  - id: 8.2
+    text: "Verify the kubeconfig file ownership of root:root"
     audit: "stat -c %U:%G /etc/origin/node/node.kubeconfig"
     tests:
       test_items:
@@ -252,8 +251,8 @@ groups:
         chown root:root /etc/origin/node/node.kubeconfig
       scored: true
 
-  - id: 2.2.3
-    text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Scored)"
+  - id: 8.3
+    text: "Verify the kubelet service file permissions of 644"
     audit: "stat -c %a /etc/systemd/system/atomic-openshift-node.service"
     tests:
       bin_op: or
@@ -278,8 +277,8 @@ groups:
       chmod 644 /etc/systemd/system/atomic-openshift-node.service
     scored: true
 
-  - id: 2.2.4
-    text: "Ensure that the kubelet service file ownership is set to root:root (Scored)"
+  - id: 8.4
+    text: "Verify the kubelet service file ownership of root:root"
     audit: "stat -c %U:%G /etc/systemd/system/atomic-openshift-node.service"
     tests:
       test_items:
@@ -293,8 +292,8 @@ groups:
         chown root:root /etc/systemd/system/atomic-openshift-node.service
       scored: true
 
-  - id: 2.2.5
-    text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive (Scored)"
+  - id: 8.5
+    text: "Verify the OpenShift default permissions for the proxy kubeconfig file"
     audit: "stat -c %a /etc/origin/node/node.kubeconfig"
     tests:
       bin_op: or
@@ -319,8 +318,8 @@ groups:
       chmod 644 /etc/origin/node/node.kubeconfig
     scored: true
 
-  - id: 2.2.6
-    text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
+  - id: 8.6
+    text: "Verify the proxy kubeconfig file ownership of root:root"
     audit: "stat -c %U:%G /etc/origin/node/node.kubeconfig"
     tests:
       test_items:
@@ -334,8 +333,8 @@ groups:
         chown root:root /etc/origin/node/node.kubeconfig
       scored: true
 
-  - id: 2.2.7
-    text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
+  - id: 8.7
+    text: "Verify the OpenShift default permissions for the certificate authorities file."
     audit: "stat -c %a /etc/origin/node/client-ca.crt"
     tests:
       bin_op: or
@@ -360,8 +359,8 @@ groups:
       chmod 644 /etc/origin/node/client-ca.crt
     scored: true
 
-  - id: 2.2.8
-    text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
+  - id: 8.8
+    text: "Verify the client certificate authorities file ownership of root:root"
     audit: "stat -c %U:%G /etc/origin/node/client-ca.crt"
     tests:
       test_items:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,10 @@ if [ "$1" == "install" ]; then
     echo "  run:     docker run --rm --pid=host aquasec/kube-bench [command]"
     exit
   fi
+elif [ "$1" == "repeat" ]; then
+  echo "Now scheduling kube-bench to run every 24 hours"
+  touch repeat-logs.txt
+  ./repeat-loop.sh > repeat-logs.txt &
 else
   exec kube-bench "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,7 @@ if [ "$1" == "install" ]; then
   fi
 elif [ "$1" == "repeat" ]; then
   echo "Now scheduling kube-bench to run every 24 hours"
-  touch repeat-logs.txt
-  ./repeat-loop.sh > repeat-logs.txt &
+  ./repeat-loop.sh &
 else
   exec kube-bench "$@"
 fi

--- a/repeat-loop.sh
+++ b/repeat-loop.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+while true
+do
+  $(which kubectl) apply -f job.yaml
+  sleep 1d
+done

--- a/repeat-loop.sh
+++ b/repeat-loop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 while true
 do
-  $(which kubectl) apply -f job.yaml
+  exec kube-bench "$@"
   sleep 1d
 done

--- a/repeat-loop.sh
+++ b/repeat-loop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 while true
 do
-  exec kube-bench "$@"
+  exec kube-bench
   sleep 1d
 done


### PR DESCRIPTION
Regarding [Issue 225 (enhancement): "helm-chart for kube-bench"](https://github.com/aquasecurity/kube-bench/issues/225).

`entrypoint.sh` now includes a "repeat" option for users running kube-bench in a kubernetes cluster. This will schedule a `kubectl apply -f job.yaml` command to run every 24 hours, and will run kube-bench in that deployment. Any notifications from kubectl about the job is written to a file created called `repeat-logs.txt`.

To run:
`./entrypoint.sh repeat`

**Potential issues/improvements**:

- Currently no CLI option to stop the `repeat` (but given the infrequency of the job, a `kill` command is useful, but not elegant)
- Logging needs revamping to be more verbose/helpful (rather than just job output)
- Currently only available for users running kube-bench via a kube cluster (needs a more generic solution)

**Developed with:**

- Machine: OSX
- Kubernetes version: 1.14.0
- Minikube version: 1.0.0

Thank you!