### PR TITLE
Add flags to further filter CIS checks to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor
 dist
 .vscode/
 hack/kind.test.yaml
+
+.idea/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"
   name = "github.com/fatih/color"
   packages = ["."]
@@ -114,6 +122,14 @@
   revision = "0131db6d737cfbbfb678f8b7d92e55e27ce46224"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:1fccaaeae58b2a2f1af4dbf7eee92ff14f222e161d143bfd20082ef664f91216"
   name = "github.com/spf13/afero"
   packages = [
@@ -160,6 +176,25 @@
   pruneopts = "UT"
   revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
+  digest = "1:0bcc464dabcfad5393daf87c3f8142911d0f6c52569b837e91a1c15e890265f3"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "mock",
+  ]
+  pruneopts = "UT"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:c9c0ba9ea00233c41b91e441cfd490f34b129bbfebcb1858979623bd8de07f72"
@@ -210,7 +245,10 @@
     "github.com/jinzhu/gorm/dialects/postgres",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
     "gopkg.in/yaml.v2",
+    "k8s.io/client-go/util/jsonpath",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,6 +18,10 @@
   name = "github.com/spf13/viper"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package check
 
 import (

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -21,7 +21,7 @@ func TestCheck_Run(t *testing.T) {
 
 	for _, testCase := range testCases {
 
-		testCase.check.Run()
+		testCase.check.run()
 
 		if testCase.check.State != testCase.Expected {
 			t.Errorf("test failed, expected %s, actual %s\n", testCase.Expected, testCase.check.State)

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+// Copyright © 2017-2019 Aqua Security Software Ltd. <info@aquasec.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/check/controls.go
+++ b/check/controls.go
@@ -17,6 +17,7 @@ package check
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
 )
 
@@ -49,6 +50,7 @@ type Summary struct {
 	Info int `json:"total_info"`
 }
 
+// Predicate a predicate on the given Group and Check arguments.
 type Predicate func(group *Group, check *Check) bool
 
 // NewControls instantiates a new master Controls object.
@@ -134,6 +136,8 @@ func summarize(controls *Controls, state State) {
 		controls.Summary.Warn++
 	case INFO:
 		controls.Summary.Info++
+	default:
+		glog.Warningf("Unrecognized state %s", state)
 	}
 }
 
@@ -147,5 +151,7 @@ func summarizeGroup(group *Group, state State) {
 		group.Warn++
 	case INFO:
 		group.Info++
+	default:
+		glog.Warningf("Unrecognized state %s", state)
 	}
 }

--- a/check/controls.go
+++ b/check/controls.go
@@ -17,8 +17,7 @@ package check
 import (
 	"encoding/json"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Controls holds all controls to check for master nodes.
@@ -50,6 +49,8 @@ type Summary struct {
 	Info int `json:"total_info"`
 }
 
+type Predicate func(group *Group, check *Check) bool
+
 // NewControls instantiates a new master Controls object.
 func NewControls(t NodeType, in []byte) (*Controls, error) {
 	c := new(Controls)
@@ -73,76 +74,44 @@ func NewControls(t NodeType, in []byte) (*Controls, error) {
 	return c, nil
 }
 
-// RunGroup runs all checks in a group.
-func (controls *Controls) RunGroup(gids ...string) Summary {
-	g := []*Group{}
-	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn, controls.Info = 0, 0, 0, 0
-
-	// If no groupid is passed run all group checks.
-	if len(gids) == 0 {
-		gids = controls.getAllGroupIDs()
-	}
-
-	for _, group := range controls.Groups {
-
-		for _, gid := range gids {
-			if gid == group.ID {
-				for _, check := range group.Checks {
-					check.Run()
-					check.TestInfo = append(check.TestInfo, check.Remediation)
-					summarize(controls, check)
-					summarizeGroup(group, check)
-				}
-
-				g = append(g, group)
-			}
-		}
-	}
-
-	controls.Groups = g
-	return controls.Summary
-}
-
-// RunChecks runs the checks with the supplied IDs.
-func (controls *Controls) RunChecks(ids ...string) Summary {
-	g := []*Group{}
+// RunChecks runs the checks with the given Runner. Only checks for which the filter Predicate returns `true` will run.
+func (controls *Controls) RunChecks(runner Runner, filter Predicate) Summary {
+	var g []*Group
 	m := make(map[string]*Group)
 	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn, controls.Info = 0, 0, 0, 0
 
-	// If no groupid is passed run all group checks.
-	if len(ids) == 0 {
-		ids = controls.getAllCheckIDs()
-	}
-
 	for _, group := range controls.Groups {
 		for _, check := range group.Checks {
-			for _, id := range ids {
-				if id == check.ID {
-					check.Run()
-					check.TestInfo = append(check.TestInfo, check.Remediation)
-					summarize(controls, check)
 
-					// Check if we have already added this checks group.
-					if v, ok := m[group.ID]; !ok {
-						// Create a group with same info
-						w := &Group{
-							ID:     group.ID,
-							Text:   group.Text,
-							Checks: []*Check{},
-						}
-
-						// Add this check to the new group
-						w.Checks = append(w.Checks, check)
-
-						// Add to groups we have visited.
-						m[w.ID] = w
-						g = append(g, w)
-					} else {
-						v.Checks = append(v.Checks, check)
-					}
-
-				}
+			if !filter(group, check) {
+				continue
 			}
+
+			state := runner.Run(check)
+			check.TestInfo = append(check.TestInfo, check.Remediation)
+
+			// Check if we have already added this checks group.
+			if v, ok := m[group.ID]; !ok {
+				// Create a group with same info
+				w := &Group{
+					ID:     group.ID,
+					Text:   group.Text,
+					Checks: []*Check{},
+				}
+
+				// Add this check to the new group
+				w.Checks = append(w.Checks, check)
+				summarizeGroup(w, state)
+
+				// Add to groups we have visited.
+				m[w.ID] = w
+				g = append(g, w)
+			} else {
+				v.Checks = append(v.Checks, check)
+				summarizeGroup(v, state)
+			}
+
+			summarize(controls, state)
 		}
 	}
 
@@ -155,29 +124,8 @@ func (controls *Controls) JSON() ([]byte, error) {
 	return json.Marshal(controls)
 }
 
-func (controls *Controls) getAllGroupIDs() []string {
-	var ids []string
-
-	for _, group := range controls.Groups {
-		ids = append(ids, group.ID)
-	}
-	return ids
-}
-
-func (controls *Controls) getAllCheckIDs() []string {
-	var ids []string
-
-	for _, group := range controls.Groups {
-		for _, check := range group.Checks {
-			ids = append(ids, check.ID)
-		}
-	}
-	return ids
-
-}
-
-func summarize(controls *Controls, check *Check) {
-	switch check.State {
+func summarize(controls *Controls, state State) {
+	switch state {
 	case PASS:
 		controls.Summary.Pass++
 	case FAIL:
@@ -189,8 +137,8 @@ func summarize(controls *Controls, check *Check) {
 	}
 }
 
-func summarizeGroup(group *Group, check *Check) {
-	switch check.State {
+func summarizeGroup(group *Group, state State) {
+	switch state {
 	case PASS:
 		group.Pass++
 	case FAIL:

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package check
 
 import (
@@ -79,7 +93,7 @@ groups:
 
 func TestControls_RunChecks(t *testing.T) {
 
-	t.Run("Should run all checks", func(t *testing.T) {
+	t.Run("Should run checks matching the filter and update summaries", func(t *testing.T) {
 		// given
 		runner := new(mockRunner)
 		// and
@@ -108,15 +122,30 @@ groups:
 		// then
 		assert.Equal(t, 2, len(controls.Groups))
 		// and
-		assert.Equal(t, "G1", controls.Groups[0].ID)
-		assert.Equal(t, "G1/C1", controls.Groups[0].Checks[0].ID)
+		G1 := controls.Groups[0]
+		assert.Equal(t, "G1", G1.ID)
+		assert.Equal(t, "G1/C1", G1.Checks[0].ID)
+		assertEqualGroupSummary(t, 1, 0, 0, 0, G1)
 		// and
-		assert.Equal(t, "G2", controls.Groups[1].ID)
-		assert.Equal(t, "G2/C1", controls.Groups[1].Checks[0].ID)
+		G2 := controls.Groups[1]
+		assert.Equal(t, "G2", G2.ID)
+		assert.Equal(t, "G2/C1", G2.Checks[0].ID)
+		assertEqualGroupSummary(t, 0, 1, 0, 0, G2)
 		// and
-		// TODO We can assert that group and controls summaries are updated.
+		assert.Equal(t, 1, controls.Summary.Pass)
+		assert.Equal(t, 1, controls.Summary.Fail)
+		assert.Equal(t, 0, controls.Summary.Info)
+		assert.Equal(t, 0, controls.Summary.Warn)
 		// and
 		runner.AssertExpectations(t)
 	})
 
+}
+
+func assertEqualGroupSummary(t *testing.T, pass, fail, info, warn int, actual *Group) {
+	t.Helper()
+	assert.Equal(t, pass, actual.Pass)
+	assert.Equal(t, fail, actual.Fail)
+	assert.Equal(t, info, actual.Info)
+	assert.Equal(t, warn, actual.Warn)
 }

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -6,10 +6,21 @@ import (
 	"path/filepath"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v2"
 )
 
 const cfgDir = "../cfg/"
+
+type mockRunner struct {
+	mock.Mock
+}
+
+func (m *mockRunner) Run(c *Check) State {
+	args := m.Called(c)
+	return args.Get(0).(State)
+}
 
 // validate that the files we're shipping are valid YAML
 func TestYamlFiles(t *testing.T) {
@@ -37,4 +48,75 @@ func TestYamlFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failure walking cfg dir: %v\n", err)
 	}
+}
+
+func TestNewControls(t *testing.T) {
+
+	t.Run("Should return error when node type is not specified", func(t *testing.T) {
+		// given
+		in := []byte(`
+---
+controls:
+type: # not specified
+groups:
+`)
+		// when
+		_, err := NewControls(MASTER, in)
+		// then
+		assert.EqualError(t, err, "non-master controls file specified")
+	})
+
+	t.Run("Should return error when input YAML is invalid", func(t *testing.T) {
+		// given
+		in := []byte("BOOM")
+		// when
+		_, err := NewControls(MASTER, in)
+		// then
+		assert.EqualError(t, err, "failed to unmarshal YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `BOOM` into check.Controls")
+	})
+
+}
+
+func TestControls_RunChecks(t *testing.T) {
+
+	t.Run("Should run all checks", func(t *testing.T) {
+		// given
+		runner := new(mockRunner)
+		// and
+		in := []byte(`
+---
+type: "master"
+groups:
+- id: G1
+  checks:
+    - id: G1/C1
+- id: G2
+  checks:
+    - id: G2/C1
+`)
+		// and
+		controls, _ := NewControls(MASTER, in)
+		// and
+		runner.On("Run", controls.Groups[0].Checks[0]).Return(PASS)
+		runner.On("Run", controls.Groups[1].Checks[0]).Return(FAIL)
+		// and
+		var runAll Predicate = func(group *Group, c *Check) bool {
+			return true
+		}
+		// when
+		controls.RunChecks(runner, runAll)
+		// then
+		assert.Equal(t, 2, len(controls.Groups))
+		// and
+		assert.Equal(t, "G1", controls.Groups[0].ID)
+		assert.Equal(t, "G1/C1", controls.Groups[0].Checks[0].ID)
+		// and
+		assert.Equal(t, "G2", controls.Groups[1].ID)
+		assert.Equal(t, "G2/C1", controls.Groups[1].Checks[0].ID)
+		// and
+		// TODO We can assert that group and controls summaries are updated.
+		// and
+		runner.AssertExpectations(t)
+	})
+
 }

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+// Copyright © 2017-2019 Aqua Security Software Ltd. <info@aquasec.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -64,7 +64,7 @@ func TestNewRunFilter(t *testing.T) {
 
 		{
 			Name:       "Should return true when group flag contains group's ID",
-			FilterOpts: FilterOpts{GroupList: "G1,G2,G3"},
+			FilterOpts: FilterOpts{Scored: true, Unscored: true, GroupList: "G1,G2,G3"},
 			Group:      &check.Group{ID: "G2"},
 			Check:      &check.Check{},
 			Expected:   true,
@@ -79,7 +79,7 @@ func TestNewRunFilter(t *testing.T) {
 
 		{
 			Name:       "Should return true when check flag contains check's ID",
-			FilterOpts: FilterOpts{CheckList: "C1,C2,C3"},
+			FilterOpts: FilterOpts{Scored: true, Unscored: true, CheckList: "C1,C2,C3"},
 			Group:      &check.Group{},
 			Check:      &check.Check{ID: "C2"},
 			Expected:   true,
@@ -95,9 +95,18 @@ func TestNewRunFilter(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			filter := NewRunFilter(testCase.FilterOpts)
+			filter, _ := NewRunFilter(testCase.FilterOpts)
 			assert.Equal(t, testCase.Expected, filter(testCase.Group, testCase.Check))
 		})
 	}
+
+	t.Run("Should return error when both group and check flags are used", func(t *testing.T) {
+		// given
+		opts := FilterOpts{GroupList: "G1", CheckList: "C1"}
+		// when
+		_, err := NewRunFilter(opts)
+		// then
+		assert.EqualError(t, err, "group option and check option can't be used together")
+	})
 
 }

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/aquasecurity/kube-bench/check"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewRunFilter(t *testing.T) {
+
+	type TestCase struct {
+		Name       string
+		FilterOpts FilterOpts
+		Group      *check.Group
+		Check      *check.Check
+
+		Expected bool
+	}
+
+	testCases := []TestCase{
+		{
+			Name:       "Should return true when scored flag is enabled and check is scored",
+			FilterOpts: FilterOpts{Scored: true, Unscored: false},
+			Group:      &check.Group{},
+			Check:      &check.Check{Scored: true},
+			Expected:   true,
+		},
+		{
+			Name:       "Should return false when scored flag is enabled and check is not scored",
+			FilterOpts: FilterOpts{Scored: true, Unscored: false},
+			Group:      &check.Group{},
+			Check:      &check.Check{Scored: false},
+			Expected:   false,
+		},
+
+		{
+			Name:       "Should return true when unscored flag is enabled and check is not scored",
+			FilterOpts: FilterOpts{Scored: false, Unscored: true},
+			Group:      &check.Group{},
+			Check:      &check.Check{Scored: false},
+			Expected:   true,
+		},
+		{
+			Name:       "Should return false when unscored flag is enabled and check is scored",
+			FilterOpts: FilterOpts{Scored: false, Unscored: true},
+			Group:      &check.Group{},
+			Check:      &check.Check{Scored: true},
+			Expected:   false,
+		},
+
+		{
+			Name:       "Should return true when group flag contains group's ID",
+			FilterOpts: FilterOpts{GroupList: "G1,G2,G3"},
+			Group:      &check.Group{ID: "G2"},
+			Check:      &check.Check{},
+			Expected:   true,
+		},
+		{
+			Name:       "Should return false when group flag doesn't contain group's ID",
+			FilterOpts: FilterOpts{GroupList: "G1,G3"},
+			Group:      &check.Group{ID: "G2"},
+			Check:      &check.Check{},
+			Expected:   false,
+		},
+
+		{
+			Name:       "Should return true when check flag contains check's ID",
+			FilterOpts: FilterOpts{CheckList: "C1,C2,C3"},
+			Group:      &check.Group{},
+			Check:      &check.Check{ID: "C2"},
+			Expected:   true,
+		},
+		{
+			Name:       "Should return false when check flag doesn't contain check's ID",
+			FilterOpts: FilterOpts{CheckList: "C1,C3"},
+			Group:      &check.Group{},
+			Check:      &check.Check{ID: "C2"},
+			Expected:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			filter := NewRunFilter(testCase.FilterOpts)
+			assert.Equal(t, testCase.Expected, filter(testCase.Group, testCase.Check))
+		})
+	}
+
+}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+// Copyright © 2017-2019 Aqua Security Software Ltd. <info@aquasec.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,13 @@ import (
 	"github.com/spf13/viper"
 )
 
+type FilterOpts struct {
+	CheckList string
+	GroupList string
+	Scored    bool
+	Unscored  bool
+}
+
 var (
 	envVarsPrefix      = "KUBE_BENCH"
 	defaultKubeVersion = "1.6"
@@ -33,14 +40,13 @@ var (
 	cfgDir             string
 	jsonFmt            bool
 	pgSQL              bool
-	checkList          string
-	groupList          string
 	masterFile         = "master.yaml"
 	nodeFile           = "node.yaml"
 	federatedFile      string
 	noResults          bool
 	noSummary          bool
 	noRemediations     bool
+	filterOpts         FilterOpts
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -79,16 +85,18 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&noRemediations, "noremediations", false, "Disable printing of remediations section")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
 	RootCmd.PersistentFlags().BoolVar(&pgSQL, "pgsql", false, "Save the results to PostgreSQL")
+	RootCmd.PersistentFlags().BoolVar(&filterOpts.Scored, "scored", false, "Run only scored CIS checks")
+	RootCmd.PersistentFlags().BoolVar(&filterOpts.Unscored, "unscored", false, "Run only unscored CIS checks")
 
 	RootCmd.PersistentFlags().StringVarP(
-		&checkList,
+		&filterOpts.CheckList,
 		"check",
 		"c",
 		"",
 		`A comma-delimited list of checks to run as specified in CIS document. Example --check="1.1.1,1.1.2"`,
 	)
 	RootCmd.PersistentFlags().StringVarP(
-		&groupList,
+		&filterOpts.GroupList,
 		"group",
 		"g",
 		"",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,8 +85,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&noRemediations, "noremediations", false, "Disable printing of remediations section")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
 	RootCmd.PersistentFlags().BoolVar(&pgSQL, "pgsql", false, "Save the results to PostgreSQL")
-	RootCmd.PersistentFlags().BoolVar(&filterOpts.Scored, "scored", false, "Run only scored CIS checks")
-	RootCmd.PersistentFlags().BoolVar(&filterOpts.Unscored, "unscored", false, "Run only unscored CIS checks")
+	RootCmd.PersistentFlags().BoolVar(&filterOpts.Scored, "scored", true, "Run the scored CIS checks")
+	RootCmd.PersistentFlags().BoolVar(&filterOpts.Unscored, "unscored", true, "Run the unscored CIS checks")
 
 	RootCmd.PersistentFlags().StringVarP(
 		&filterOpts.CheckList,

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -50,15 +50,18 @@ func continueWithError(err error, msg string) string {
 	return ""
 }
 
-func cleanIDs(list string) []string {
+func cleanIDs(list string) map[string]bool {
 	list = strings.Trim(list, ",")
 	ids := strings.Split(list, ",")
 
+	set := make(map[string]bool)
+
 	for _, id := range ids {
 		id = strings.Trim(id, " ")
+		set[id] = true
 	}
 
-	return ids
+	return set
 }
 
 // ps execs out to the ps command; it's separated into a function so we can write tests


### PR DESCRIPTION
Changes:

1. Partially resolves #172 by adding support for `--scored` and `--unscored` flags
2. Some refactoring to facilitate unit testing of new/existing functionality.

Tested with unit tests and as well as minikube v1.0.0