### PR TITLE
Fix failing check 1.5.2 in version 1.11

### DIFF
--- a/cfg/1.11/master.yaml
+++ b/cfg/1.11/master.yaml
@@ -1201,8 +1201,8 @@ groups:
       test_items:
       - flag: "--client-cert-auth"
         compare:
-          op: eq
-          value: true
+          op: noteq
+          value: false
         set: true
     remediation: |
       Edit the etcd pod specification file $etcdconf on the master


### PR DESCRIPTION
Change test_items in 1.11 master.yaml check 1.5.2 to fix issue with check failing even when --client-cert-auth is set, mentioned in #270.