### PR TITLE
Fixing remediation field for json result

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -67,7 +67,7 @@ type Check struct {
 	Commands    []*exec.Cmd `json:"omit"`
 	Tests       *tests      `json:"omit"`
 	Set         bool        `json:"omit"`
-	Remediation string      `json:"-"`
+	Remediation string      `json:"remediation"`
 	TestInfo    []string    `json:"test_info"`
 	State       `json:"status"`
 	ActualValue string `json:"actual_value"`


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/kube-bench/issues/278

remediation field is missing in the json result and the actual remediation text shows up in test_info field.

After the fix:
```
./kube-bench master --version 1.13 --json -c 1.1.1 | jq .
{
  "id": "1",
  "version": "1.13",
  "text": "Master Node Security Configuration",
  "node_type": "master",
  "tests": [
    {
      "section": "1.1",
      "pass": 0,
      "fail": 0,
      "warn": 0,
      "info": 0,
      "desc": "API Server",
      "results": [
        {
          "test_number": "1.1.1",
          "test_desc": "Ensure that the --anonymous-auth argument is set to false (Not Scored)",
          "type": "",
          "remediation": "Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml\non the master node and set the below parameter.\n--anonymous-auth=false\n",
          "test_info": null,
          "status": "WARN",
          "actual_value": "",
          "scored": false
        }
      ]
    }
  ],
  "total_pass": 0,
  "total_fail": 0,
  "total_warn": 1,
  "total_info": 0
}
```