### PR TITLE
Genereate expected result automatically for each test

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -72,6 +72,7 @@ type Check struct {
 	State       `json:"status"`
 	ActualValue string `json:"actual_value"`
 	Scored      bool   `json:"scored"`
+	ExpectedResult string `json:"expected_result"`
 }
 
 // Runner wraps the basic Run method.
@@ -188,6 +189,7 @@ func (c *Check) run() State {
 	finalOutput := c.Tests.execute(out.String())
 	if finalOutput != nil {
 		c.ActualValue = finalOutput.actualResult
+		c.ExpectedResult = finalOutput.ExpectedResult
 		if finalOutput.testResult {
 			c.State = PASS
 		} else {

--- a/check/test.go
+++ b/check/test.go
@@ -219,8 +219,11 @@ func (ts *tests) execute(s string) *testOutput {
 		return finalOutput
 	}
 
+	expectedResultArr := make([]string, len(res))
+
 	for i, t := range ts.TestItems {
 		res[i] = *(t.execute(s))
+		expectedResultArr[i] = res[i].ExpectedResult
 	}
 
 	var result bool
@@ -232,19 +235,18 @@ func (ts *tests) execute(s string) *testOutput {
 	case and, "":
 		result = true
 		for i := range res {
-			finalOutput.ExpectedResult += fmt.Sprintf("%s AND ", res[i].ExpectedResult)
 			result = result && res[i].testResult
 		}
-		// Delete last iteration ' AND '
-		finalOutput.ExpectedResult = finalOutput.ExpectedResult[:len(finalOutput.ExpectedResult)-5]
+		// Generate an AND expected result
+		finalOutput.ExpectedResult = strings.Join(expectedResultArr, " AND ")
+
 	case or:
 		result = false
 		for i := range res {
-			finalOutput.ExpectedResult += fmt.Sprintf("%s OR ", res[i].ExpectedResult)
 			result = result || res[i].testResult
 		}
-		// Delete last iteration ' OR '
-		finalOutput.ExpectedResult = finalOutput.ExpectedResult[:len(finalOutput.ExpectedResult)-4]
+		// Generate an OR expected result
+		finalOutput.ExpectedResult = strings.Join(expectedResultArr, " OR ")
 	}
 
 	finalOutput.testResult = result


### PR DESCRIPTION
The expected result of each test, is generated from the test arguments from the yaml file.
Every expected result is a combination of expressions, separated by the binary operand (or/and).
Every expression is combined from the test item attributes:
flag, set and if there is - compare operand and compare value.

Example:
tests:
bin_op: or
test_items:
- flag: "--cgroup-parent"
set: false
- flag: "--cgroup-parent"
compare:
op: nothave
value: "/docker"
set: true
Expected result will be shown as: '--cgroup-parent' Is not present OR '--cgroup-parent' Not have '/docker'

Another example:
tests:
test_items:
- flag: "userns"
compare:
op: has
value: "userns"
set: true
Expected result will be shown as: 'userns' Has 'userns'