### PR TITLE
Dln/kops paths

### DIFF
--- a/cfg/1.11/config.yaml
+++ b/cfg/1.11/config.yaml
@@ -34,9 +34,8 @@ master:
 
 node:
   kubelet:
-    defaultconf: /var/lib/kubelet/config.yaml
+    defaultconf: /etc/kubernetes/kubelet.conf
     defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    defaultkubeconfig: /etc/kubernetes/kubelet.conf
 
   proxy:
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.11/config.yaml
+++ b/cfg/1.11/config.yaml
@@ -9,21 +9,34 @@
 
 master:
   apiserver:
+    confs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
+    confs:
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
+    confs:
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
+    confs:
+      - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 node:
   kubelet:
-    defaultconf: /etc/kubernetes/kubelet.conf
+    defaultconf: /var/lib/kubelet/config.yaml
     defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    defaultkubeconfig: /etc/kubernetes/kubelet.conf
 
   proxy:
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.13/config.yaml
+++ b/cfg/1.13/config.yaml
@@ -34,9 +34,8 @@ master:
 
 node:
   kubelet:
-    defaultconf: /var/lib/kubelet/config.yaml
+    defaultconf: /etc/kubernetes/kubelet.conf
     defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    defaultkubeconfig: /etc/kubernetes/kubelet.conf
 
   proxy:
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.13/config.yaml
+++ b/cfg/1.13/config.yaml
@@ -9,21 +9,34 @@
 
 master:
   apiserver:
+    confs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/manifests/kube-apiserver.yaml
 
   scheduler:
+    confs:
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.manifest
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
+    confs:
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.manifest
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
+    confs:
+      - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 node:
   kubelet:
-    defaultconf: /etc/kubernetes/kubelet.conf
+    defaultconf: /var/lib/kubelet/config.yaml
     defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    defaultkubeconfig: /etc/kubernetes/kubelet.conf
 
   proxy:
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml


### PR DESCRIPTION
Relates to [235](https://github.com/aquasecurity/kube-bench/issues/235) :

- Configs for 1.11 and 1.13 now include the same set of file locations as in the 1.8 config. Previously, that resulted in a few false-positives on Kubernetes clusters set up via KOPS