### PR TITLE
Config improvements

### DIFF
--- a/cfg/1.11-json/config.yaml
+++ b/cfg/1.11-json/config.yaml
@@ -9,10 +9,6 @@ node:
       - "/var/lib/kubelet/kubeconfig"
 
   kubelet:
-    bins:
-      - "hyperkube kubelet"
-      - "kubelet"
-    defaultconf: "/etc/kubernetes/kubelet/kubelet-config.json"
     defaultsvc: "/etc/systemd/system/kubelet.service"
     defaultkubeconfig: "/var/lib/kubelet/kubeconfig"
 

--- a/cfg/1.11/config.yaml
+++ b/cfg/1.11/config.yaml
@@ -31,11 +31,3 @@ master:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
-
-node:
-  kubelet:
-    defaultconf: /etc/kubernetes/kubelet.conf
-    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-
-  proxy:
-    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.13/config.yaml
+++ b/cfg/1.13/config.yaml
@@ -31,11 +31,3 @@ master:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
-
-node:
-  kubelet:
-    defaultconf: /etc/kubernetes/kubelet.conf
-    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-
-  proxy:
-    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -220,12 +220,15 @@ groups:
     text: "Ensure that the admission control plugin NamespaceLifecycle is set (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
+      bin_op: or
       test_items:
       - flag: "--disable-admission-plugins"
         compare:
           op: nothave
           value: "NamespaceLifecycle"
         set: true
+      - flag: "--disable-admission-plugins"
+        set: false
     remediation: |
       Edit the API server pod specification file $apiserverconf
       on the master node and set the --disable-admission-plugins parameter to

--- a/cfg/1.8/config.yaml
+++ b/cfg/1.8/config.yaml
@@ -31,12 +31,3 @@ master:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
-
-node:
-  kubelet:
-    defaultconf: /var/lib/kubelet/config.yaml
-    defaultsvc: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    defaultkubeconfig: /etc/kubernetes/kubelet.conf
-  
-  proxy:
-    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -81,6 +81,9 @@ node:
     bins:
       - "hyperkube kubelet"
       - "kubelet"
+    confs:
+      - "/var/lib/kubelet/config.yaml"
+      - "/etc/kubernetes/kubelet/kubelet-config.json"
     defaultconf: "/var/lib/kubelet/config.yaml"
     defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
     defaultkubeconfig: "/etc/kubernetes/kubelet.conf"
@@ -93,6 +96,7 @@ node:
     confs:
       - /etc/kubernetes/proxy
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
+    defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     defaultkubeconfig: "/etc/kubernetes/proxy.conf"
 
 federated:


### PR DESCRIPTION
* Move some default values for kubelet and proxy into `cfg/config.yaml` so they don't have to be defined in version-specific files
* #193 fixed the file for 1.11 but not 1.13 - now fixed