### PR TITLE
Document version-specific config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ kube-bench includes a set of test files for Red Hat's OpenShift hardening guide 
 
 Kubernetes config and binary file locations and names can vary from installation to installation, so these are configurable in the `cfg/config.yaml` file.
 
+Any settings in the version-specific config file `cfg/<version>/config.yaml` take precedence over settings in the main `cfg/config.yaml` file.
+
 For each type of node (*master*, *node* or *federated*) there is a list of components, and for each component there is a set of binaries (*bins*) and config files (*confs*) that kube-bench will look for (in the order they are listed). If your installation uses a different binary name or config file location for a Kubernetes component, you can add it to `cfg/config.yaml`.
 
 * **bins** - If there is a *bins* list for a component, at least one of these binaries must be running. The tests will consider the parameters for the first binary in the list found to be running.


### PR DESCRIPTION
Values in the version-specific files override the main file.

I think this is the last outstanding item to-do for #235 