### PR TITLE
ocp-3.10: Fix malformed yaml and improve TestControls_RunChecks

### DIFF
--- a/cfg/ocp-3.10/node.yaml
+++ b/cfg/ocp-3.10/node.yaml
@@ -196,7 +196,7 @@ groups:
   - id: 7.15
     text: "Verify that the RotateKubeletServerCertificate argument is set to true"
     audit: "grep -B1 RotateKubeletServerCertificate=true /etc/origin/node/node-config.yaml"
-    test:
+    tests:
       test_items:
       - flag: "RotateKubeletServerCertificate=true"
         compare:


### PR DESCRIPTION
This improves the TestControls_RunChecks() test by making
more comprehensive assertions on a more fully fledged input yaml

Fixes: https://github.com/aquasecurity/kube-bench/issues/304

Signed-off-by: Simarpreet Singh <simar@linux.com>