### PR TITLE
kube-bench: add version subcommand

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var KubeBenchVersion string
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Shows the version of kube-bench.",
+	Long:  `Shows the version of kube-bench.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(KubeBenchVersion)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@ SOURCES := $(shell find . -name '*.go')
 BINARY := kube-bench
 DOCKER_REGISTRY ?= aquasec
 VERSION ?= $(shell git rev-parse --short=7 HEAD)
+KUBEBENCH_VERSION ?= $(shell git describe --tags --abbrev=0)
 IMAGE_NAME ?= $(DOCKER_REGISTRY)/$(BINARY):$(VERSION)
 TARGET_OS := linux
 BUILD_OS := linux
@@ -22,7 +23,7 @@ KIND_CONTAINER_NAME=$(KIND_PROFILE)-control-plane
 build: kube-bench
 
 $(BINARY): $(SOURCES)
-	GOOS=$(TARGET_OS) go build -o $(BINARY) .
+	GOOS=$(TARGET_OS) go build -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=$(KUBEBENCH_VERSION)" -o $(BINARY) .
 
 # builds the current dev docker version
 build-docker:


### PR DESCRIPTION
This commit adds a version subcommand to display the kube-bench release version

Usage:
```
$ kube-bench version
V0.0.27
```

Addresses: https://github.com/aquasecurity/kube-bench/issues/311


Signed-off-by: Simarpreet Singh <simar@linux.com>