### PR TITLE
add glog flush to write the output to a file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,8 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+	// flush after exit
+	glog.Flush()
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,9 +74,11 @@ func Execute() {
 
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
+		// flush before exit non-zero
+		glog.Flush()
 		os.Exit(-1)
 	}
-	// flush after exit
+	// flush before exit
 	glog.Flush()
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -35,6 +35,8 @@ func init() {
 
 func exitWithError(err error) {
 	fmt.Fprintf(os.Stderr, "\n%v\n", err)
+	// flush before exit non-zero
+	glog.Flush()
 	os.Exit(1)
 }
 


### PR DESCRIPTION
```kube-bench master  --logtostderr=false   -v 9```

 ```cat /tmp/kube-bench.INFO
Log file created at: 2019/06/28 00:01:03
Running on machine: kubemaster1
Binary: Built with gc go1.11.11 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
```

It does not log anything else after that. 

After the fix we can see the output being recorded to the file: 

```cat /tmp/kube-bench.INFO
Log file created at: 2019/06/28 00:02:27
Running on machine: kubemaster1
Binary: Built with gc go1.12 for linux/amd64
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0628 00:02:27.340695 3203197 util.go:122] Looking for config for version 1.13
I0628 00:02:27.340919 3203197 util.go:127] Looking for config file: cfg/1.13/master.yaml
I0628 00:02:27.340960 3203197 util.go:127] Looking for config file: cfg/1.12/master.yaml
...
...
```

As per https://github.com/golang/glog/blob/master/glog.go#L878 

`const flushInterval = 30 * time.Second` is the flush interval. 

https://github.com/golang/glog/blob/master/glog.go#L35-L36
```
// Log output is buffered and written periodically using Flush. Programs
// should call Flush before exiting to guarantee all log output is written
```

kube-bench exists before 30 seconds and it could not flush the output to a log directory. 
