### PR TITLE
fix go.mod dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/mrueg/kube-bench
+module github.com/aquasecurity/kube-bench
 
 go 1.12
 
 require (
-	github.com/aquasecurity/kube-bench v0.0.29
 	github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3 // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/fatih/color v1.5.0


### PR DESCRIPTION
Due to go mod pointing to`	github.com/aquasecurity/kube-bench v0.0.29	` at line#6, it does not honor the current code and points to the dependency cache.
