### PR TITLE
Update kube-api server flag experimental-encryption-provider-config  to encryption-provider-config for 1.13

### DIFF
--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -556,19 +556,19 @@ groups:
     scored: true
 
   - id: 1.1.34
-    text: "Ensure that the --experimental-encryption-provider-config argument is
+    text: "Ensure that the --encryption-provider-config argument is
     set as appropriate (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
       test_items:
-      - flag: "--experimental-encryption-provider-config"
+      - flag: "--encryption-provider-config"
         set: true
     remediation: |
       Follow the Kubernetes documentation and configure a EncryptionConfig file.
       Then, edit the API server pod specification file $apiserverconf on the
-      master node and set the --experimental-encryption-provider-config parameter
+      master node and set the --encryption-provider-config parameter
       to the path of that file:
-      --experimental-encryption-provider-config=</path/to/EncryptionConfig/File>
+      --encryption-provider-config=</path/to/EncryptionConfig/File>
     scored: true
 
   - id: 1.1.35


### PR DESCRIPTION
Kube-api server flag is deprecated in 1.13 `experimental-encryption-provider-config` and changed to `encryption-provider-config`. Here are the more details from the changelog of 1.13. 

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.13.md#deprecations

`The --experimental-encryption-provider-config flag is deprecated in favor of --encryption-provider-config. The old flag is accepted with a warning but will be removed in 1.14. (#71206, @stlaz)`


