### PR TITLE
issue #337: Adds comment for properties detected thru parsing command…

### DIFF
--- a/cfg/1.11-json/node.yaml
+++ b/cfg/1.11-json/node.yaml
@@ -10,6 +10,9 @@ groups:
   checks:
   - id: 2.1.1
     text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+    # This is one of those properties that can only be set as a command line argument. 
+    # To check if the property is set as expected, we need to parse the kubelet command 
+    # instead reading the Kubelet Configuration file.
     audit: "ps -fC $kubeletbin"
     tests:
       test_items:

--- a/cfg/1.13-json/node.yaml
+++ b/cfg/1.13-json/node.yaml
@@ -160,7 +160,10 @@ groups:
 
   - id: 2.1.8
     text: "Ensure that the --hostname-override argument is not set (Scored)"
-    audit: "cat $kubeletconf"
+    # This is one of those properties that can only be set as a command line argument. 
+    # To check if the property is set as expected, we need to parse the kubelet command 
+    # instead reading the Kubelet Configuration file.
+    audit: "ps -fC $kubeletbin"
     tests:
       test_items:
       - flag: "--hostname-override"
@@ -221,7 +224,10 @@ groups:
 
   - id: 2.1.11
     text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
-    audit: "cat $kubeletconf"
+    # This is one of those properties that can only be set as a command line argument. 
+    # To check if the property is set as expected, we need to parse the kubelet command 
+    # instead reading the Kubelet Configuration file.
+    audit: "ps -fC $kubeletbin"
     tests:
       bin_op: or
       test_items:


### PR DESCRIPTION
 - Adds comment for properties detected thru parsing command. 
- Fixed Audit for test 2.1.8 to use `ps` instead of cat'ing the kubelet configuration file.