### PR TITLE
turns Go Module on

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+env:
+  - GO111MODULE=on
 builds:
   - main: main.go
     binary: kube-bench


### PR DESCRIPTION
This change should fix the Travis build error while **goreleaser** fails to build due to missing dependencies.