### PR TITLE
Fixes bugs on tests 2.1.4 and 2.1.5 - 1.13-json

### DIFF
--- a/cfg/1.13-json/node.yaml
+++ b/cfg/1.13-json/node.yaml
@@ -98,12 +98,15 @@ groups:
     text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
     audit: "cat $kubeletconf"
     tests:
+      bin_op: or
       test_items:
       - path: "{.streamingConnectionIdleTimeout}"
         compare:
           op: noteq
           value: 0
         set: true
+      - path: "{.streamingConnectionIdleTimeout}"
+        set: false
     remediation: |
       If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
       value other than 0.

--- a/cfg/1.13-json/node.yaml
+++ b/cfg/1.13-json/node.yaml
@@ -74,12 +74,15 @@ groups:
     text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
     audit: "cat $kubeletconf"
     tests:
+      bin_op: or
       test_items:
       - path: "{.readOnlyPort}"
         compare:
           op: eq
           value: 0
         set: true
+      - path: "{.readOnlyPort}"
+        set: false
     remediation: |
       If using a Kubelet config file, edit the file to set readOnlyPort to 0 .
       If using command line arguments, edit the kubelet service file


### PR DESCRIPTION
Adds `bin_op` to fix bugs on tests 2.1.4 and 2.1.5 - 1.13-json