### PR TITLE
fixes-according-kube-cis1.4.1

### DIFF
--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -183,9 +183,8 @@ groups:
     scored: true
 
   - id: 1.1.12
-    text: "Ensure that the admission control plugin DenyEscalatingExec is set (Scored)"
+    text: "[DEPRECATED] Ensure that the admission control plugin DenyEscalatingExec is set (Not Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
-    # [DEPRECATED]
     type: skip
     tests:
       test_items:
@@ -199,7 +198,7 @@ groups:
       on the master node and set the --enable-admission-plugins parameter to a
       value that includes DenyEscalatingExec.
       --enable-admission-plugins=...,DenyEscalatingExec,...
-    scored: true
+    scored: false
 
   - id: 1.1.13
     text: "Ensure that the admission control plugin SecurityContextDeny is set (Scored)"
@@ -564,9 +563,6 @@ groups:
     tests:
       test_items:
       - flag: "--encryption-provider-config"
-        compare:
-          op: has
-          value: "</path/to/EncryptionConfig/File>"
         set: true
     remediation: |
       Follow the Kubernetes documentation and configure a EncryptionConfig file.

--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -185,6 +185,8 @@ groups:
   - id: 1.1.12
     text: "Ensure that the admission control plugin DenyEscalatingExec is set (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    # [DEPRECATED]
+    type: skip
     tests:
       test_items:
       - flag: "--enable-admission-plugins"
@@ -556,19 +558,22 @@ groups:
     scored: true
 
   - id: 1.1.34
-    text: "Ensure that the --experimental-encryption-provider-config argument is
-    set as appropriate (Scored)"
+    text: "Ensure that the --encryption-provider-config argument is set as appropriate (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
     tests:
       test_items:
-      - flag: "--experimental-encryption-provider-config"
+      - flag: "--encryption-provider-config"
+        compare:
+          op: has
+          value: "</path/to/EncryptionConfig/File>"
         set: true
     remediation: |
       Follow the Kubernetes documentation and configure a EncryptionConfig file.
       Then, edit the API server pod specification file $apiserverconf on the
-      master node and set the --experimental-encryption-provider-config parameter
+      master node and set the --encryption-provider-config parameter
       to the path of that file:
-      --experimental-encryption-provider-config=</path/to/EncryptionConfig/File>
+      --encryption-provider-config=</path/to/EncryptionConfig/File>
     scored: true
 
   - id: 1.1.35

--- a/cfg/1.13/node.yaml
+++ b/cfg/1.13/node.yaml
@@ -220,9 +220,8 @@ groups:
     scored: true
 
   - id: 2.1.11
-    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+    text: "[DEPRECATED] Ensure that the --cadvisor-port argument is set to 0 (Not Scored)"
     audit: "ps -fC $kubeletbin"
-    # [DEPRECATED]
     type: skip
     tests:
       bin_op: or
@@ -241,7 +240,7 @@ groups:
       Based on your system, restart the kubelet service. For example:
       systemctl daemon-reload
       systemctl restart kubelet.service
-    scored: true
+    scored: false
 
   - id: 2.1.12
     text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"

--- a/cfg/1.13/node.yaml
+++ b/cfg/1.13/node.yaml
@@ -222,6 +222,8 @@ groups:
   - id: 2.1.11
     text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
     audit: "ps -fC $kubeletbin"
+    # [DEPRECATED]
+    type: skip
     tests:
       bin_op: or
       test_items:


### PR DESCRIPTION
test 1.1.12 got DEPRECATED.
test 1.1.34 changed to --encryption-provider-config and need to be set manually