### PR TITLE
Correction to 1.13 and 1.13-json test 2.1.5

### DIFF
--- a/cfg/1.11/node.yaml
+++ b/cfg/1.11/node.yaml
@@ -114,12 +114,15 @@ groups:
     text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
     audit: "ps -fC $kubeletbin"
     tests:
+      bin_op: or
       test_items:
       - flag: "--streaming-connection-idle-timeout"
         compare:
           op: noteq
           value: 0
         set: true
+      - flag: "--streaming-connection-idle-timeout"
+        set: false
     remediation: |
       If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
       value other than 0.

--- a/cfg/1.13/node.yaml
+++ b/cfg/1.13/node.yaml
@@ -95,12 +95,15 @@ groups:
     text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
     audit: "ps -fC $kubeletbin"
     tests:
+      bin_op: or
       test_items:
       - flag: "--streaming-connection-idle-timeout"
         compare:
           op: noteq
           value: 0
         set: true
+      - flag: "--streaming-connection-idle-timeout"
+        set: false
     remediation: |
       If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
       value other than 0.


### PR DESCRIPTION
according to [issue 347](https://github.com/aquasecurity/kube-bench/issues/347) ive been allowing the default streaming-connection-idle-timeout for both 1.11 and 1.13
