### PR TITLE
Read kubernetes version from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ You can choose to
 kube-bench automatically selects which `controls` to use based on the detected
 node type and the version of kubernetes a cluster is running. This behaviour
 can be overridden by specifying the `master` or `node` subcommand and the
-`--version` flag on the command line.
+`--version` flag on the command line. 
+
+The kubernetes version can also be set with the KUBE_BENCH_VERSION environment variable.
+The value of `--version` takes precedence over the value of KUBE_BENCH_VERSION.
 
 For example:
 run kube-bench against a master with version auto-detection:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,8 +130,16 @@ func initConfig() {
 		viper.AddConfigPath(cfgDir)   // adding ./cfg as first search path
 	}
 
+	// Read flag values from environment variables.
+	// Precedence: Command line flags take precedence over environment variables.
 	viper.SetEnvPrefix(envVarsPrefix)
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv()
+	
+	if kubeVersion == "" {
+		if env := viper.Get("version"); env != nil {
+			kubeVersion = env.(string)
+		}
+ 	}
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
Fixes #152

Set kubernetes version to the value of the environment variable `KUBE_BENCH_VERSION` if it is defined and the flag `--version` is not specified on the kube-bench command line.

The command line flag `--version` takes precedence of the environment variable `KUBE_BENCH_VERSION` if both are defined.