### PR TITLE
Fix error converting from string to integer

### DIFF
--- a/cfg/1.6/node.yaml
+++ b/cfg/1.6/node.yaml
@@ -83,7 +83,7 @@ groups:
         test_items:
           - flag: "--streaming-connection-idle-timeout"
             compare:
-              op: gt
+              op: noteq
               value: 0
             set: true
       remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 


### PR DESCRIPTION
Fix #291 

Replace the `gt` with `eq` for string comparison of kube-bench check 2.1.6 in `cfg/1.6/node.yaml`.