### PR TITLE
hyperkube v1.15 renamed "proxy" to "kube-proxy"

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -120,6 +120,7 @@ node:
     bins:
       - "kube-proxy"
       - "hyperkube proxy"
+      - "hyperkube kube-proxy"
       - "proxy"
     confs:
       - /etc/kubernetes/proxy


### PR DESCRIPTION
This is another fix that's needed for issue #386 
 hyperkube v1.15 renamed "proxy" to "kube-proxy"