### PR TITLE
update the yaml according cis kube benchmark  1.4.1

### DIFF
--- a/cfg/1.13-json/node.yaml
+++ b/cfg/1.13-json/node.yaml
@@ -226,11 +226,12 @@ groups:
     scored: true
 
   - id: 2.1.11
-    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+    text: "[DEPRECATED] Ensure that the --cadvisor-port argument is set to 0"
     # This is one of those properties that can only be set as a command line argument. 
     # To check if the property is set as expected, we need to parse the kubelet command 
     # instead reading the Kubelet Configuration file.
     audit: "ps -fC $kubeletbin"
+    type: skip
     tests:
       bin_op: or
       test_items:
@@ -248,7 +249,7 @@ groups:
       Based on your system, restart the kubelet service. For example:
       systemctl daemon-reload
       systemctl restart kubelet.service
-    scored: true
+    scored: false
 
   - id: 2.1.12
     text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"


### PR DESCRIPTION
The update is from the new cis version 1.4.1.
like asked in https://github.com/aquasecurity/kube-bench/issues/370
and already been done in the 1.13 
https://github.com/aquasecurity/kube-bench/pull/376