### PR TITLE
docs: note that you may need to be root

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can choose to
 
 ## Running kube-bench
 
+If you run kube-bench directly from the command line you may need to be root / sudo in order to have access to all the config files.
+
 kube-bench automatically selects which `controls` to use based on the detected
 node type and the version of kubernetes a cluster is running. This behaviour
 can be overridden by specifying the `master` or `node` subcommand and the


### PR DESCRIPTION
We're now potentially looking at config files for which you might need to be root to even see. This can result in errors like:

`error looking for file /var/lib/kubelet/config.yaml: stat /var/lib/kubelet/config.yaml: permission denied`

If you're running as a container you effectively get this anyway so I don't think it's unreasonable to run as root, though we could consider an issue to warn (but carry on) when this happens.