### PR TITLE
Make kube-bench enabled to run on worker node for AKS

### DIFF
--- a/cfg/1.13/node.yaml
+++ b/cfg/1.13/node.yaml
@@ -433,7 +433,25 @@ groups:
     - id: 2.2.7
       text: "Ensure that the certificate authorities file permissions are set to
       644 or more restrictive (Scored)"
-      type: manual
+      audit: "/bin/sh -c 'if test -e $kubeletcafile; then stat -c %a $kubeletcafile; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
       remediation: |
         Run the following command to modify the file permissions of the --client-ca-file
         chmod 644 <filename>

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -126,7 +126,8 @@ node:
       - /etc/kubernetes/proxy
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
     kubeconfig:
-      - /etc/kubernetes/kubelet-kubeconfig
+      - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/var/lib/kubelet/kubeconfig"
     svc:
       - "/lib/systemd/system/kube-proxy.service"
     defaultconf: /etc/kubernetes/addons/kube-proxy-daemonset.yaml

--- a/job-aks.yaml
+++ b/job-aks.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench-node
+spec:
+  template:
+    spec:
+      hostPID: true
+      containers:
+      - name: kube-bench
+        image: aquasec/kube-bench:latest
+        command: ["kube-bench", "--version", "1.13", "node"]
+        volumeMounts:
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: etc-systemd
+          mountPath: /etc/systemd
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version. 
+          # You can omit this mount if you specify --version as part of the command.           
+        - name: usr-bin
+          mountPath: /usr/bin
+      restartPolicy: Never
+      volumes:
+      - name: var-lib-kubelet
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: etc-systemd
+        hostPath:
+          path: "/etc/systemd"
+      - name: etc-kubernetes
+        hostPath:
+          path: "/etc/kubernetes"
+      - name: usr-bin
+        hostPath:
+          path: "/usr/local/bin"


### PR DESCRIPTION
For what I changed, please look at this issue.
https://github.com/aquasecurity/kube-bench/issues/421

I am not from Microsoft so review from anyone who is from Microsoft or have deep knowledge on AKS will be appreciated.
