### PR TITLE
cfg: Make proxy checks optional

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -117,6 +117,7 @@ node:
     defaultcafile: "/etc/kubernetes/pki/ca.crt"
 
   proxy:
+    optional: true
     bins:
       - "kube-proxy"
       - "hyperkube proxy"


### PR DESCRIPTION
This PR will make checking for the proxy binary optional.

Addresses: https://github.com/aquasecurity/kube-bench/issues/335 

Signed-off-by: Simarpreet Singh <simar@linux.com>