### PR TITLE
Fix detection of encryption-provider-config

### DIFF
--- a/cfg/1.13/master.yaml
+++ b/cfg/1.13/master.yaml
@@ -565,7 +565,6 @@ groups:
   - id: 1.1.34
     text: "Ensure that the --encryption-provider-config argument is set as appropriate (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
-    type: "manual"
     tests:
       test_items:
       - flag: "--encryption-provider-config"


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/kube-bench/issues/420
Dropping the `type: "manual"` key here, let's it detect it properly.