### PR TITLE
Use newer `kind load docker-image` command

### DIFF
--- a/makefile
+++ b/makefile
@@ -48,10 +48,7 @@ endif
 
 # pushses the current dev version to the kind cluster.
 kind-push:
-	docker save $(IMAGE_NAME) -o kube-bench.tar.gz; \
-	docker cp kube-bench.tar.gz $(KIND_CONTAINER_NAME):/kube-bench.tar.gz; \
-	docker exec $(KIND_CONTAINER_NAME) docker load -i /kube-bench.tar.gz;
-	-rm -f kube-bench.tar.gz
+	kind load docker-image $(IMAGE_NAME) --name $(KIND_PROFILE)
 
 # runs the current version on kind using a job and follow logs
 kind-run: KUBECONFIG = "$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")"


### PR DESCRIPTION
Updates the logic for `kind-push` in the makefile to use
the new, simple command provided by kind.

Fixes #458