### PR TITLE
Fixes Issue #331: Changes the Error Message When Programs are Missing  

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -213,7 +213,7 @@ func loadConfig(nodetype check.NodeType) string {
 	if kubeVersion == "" {
 		runningVersion, err = getKubeVersion()
 		if err != nil {
-			exitWithError(fmt.Errorf("Version check failed: %s\nAlternatively, you can specify the version with --version", err))
+			exitWithError(fmt.Errorf("Version check failed: \n%s", err))
 		}
 	}
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -81,7 +81,7 @@ func runChecks(nodetype check.NodeType) {
 
 	// Get the set of executables and config files we care about on this type of node.
 	typeConf := viper.Sub(string(nodetype))
-	binmap, err := getBinaries(typeConf)
+	binmap, err := getBinaries(typeConf, nodetype)
 
 	// Checks that the executables we need for the node type are running.
 	if err != nil {
@@ -245,7 +245,7 @@ func isMaster() bool {
 		glog.V(2).Info("No master components found to be running")
 		return false
 	}
-	components, err := getBinariesFunc(masterConf)
+	components, err := getBinariesFunc(masterConf, check.MASTER)
 
 	if err != nil {
 		glog.V(2).Info(err)

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -16,10 +16,11 @@ package cmd
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewRunFilter(t *testing.T) {
@@ -114,44 +115,44 @@ func TestNewRunFilter(t *testing.T) {
 }
 
 func TestIsMaster(t *testing.T) {
-	testCases := []struct{
-		name string
-		cfgFile string
-		getBinariesFunc func(*viper.Viper) (map[string]string, error)
-		isMaster bool
+	testCases := []struct {
+		name            string
+		cfgFile         string
+		getBinariesFunc func(*viper.Viper, check.NodeType) (map[string]string, error)
+		isMaster        bool
 	}{
 		{
-			name: "valid config, is master and all components are running",
+			name:    "valid config, is master and all components are running",
 			cfgFile: "../cfg/config.yaml",
-			getBinariesFunc: func(viper *viper.Viper) (strings map[string]string, i error) {
+			getBinariesFunc: func(viper *viper.Viper, nt check.NodeType) (strings map[string]string, i error) {
 				return map[string]string{"apiserver": "kube-apiserver"}, nil
 			},
 			isMaster: true,
 		},
 		{
-			name: "valid config, is master and but not all components are running",
+			name:    "valid config, is master and but not all components are running",
 			cfgFile: "../cfg/config.yaml",
-			getBinariesFunc: func(viper *viper.Viper) (strings map[string]string, i error) {
+			getBinariesFunc: func(viper *viper.Viper, nt check.NodeType) (strings map[string]string, i error) {
 				return map[string]string{}, nil
 			},
 			isMaster: false,
 		},
 		{
-			name: "valid config, is master, not all components are running and fails to find all binaries",
+			name:    "valid config, is master, not all components are running and fails to find all binaries",
 			cfgFile: "../cfg/config.yaml",
-			getBinariesFunc: func(viper *viper.Viper) (strings map[string]string, i error) {
+			getBinariesFunc: func(viper *viper.Viper, nt check.NodeType) (strings map[string]string, i error) {
 				return map[string]string{}, errors.New("failed to find binaries")
 			},
 			isMaster: false,
 		},
 		{
-			name: "valid config, does not include master",
-			cfgFile: "../cfg/node_only.yaml",
+			name:     "valid config, does not include master",
+			cfgFile:  "../cfg/node_only.yaml",
 			isMaster: false,
 		},
 	}
 
-	for _, tc := range testCases{
+	for _, tc := range testCases {
 		cfgFile = tc.cfgFile
 		initConfig()
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -368,7 +368,7 @@ func buildComponentMissingErrorMessage(nodetype check.NodeType, component string
 	errTemplate := `
 Unable to find %s programs (%s, etc...)
 These program names are provided in the config.yaml, section %s.%s.bins
-The following %s programs for the component '%s' have been search, 
+The following %s programs for the component '%s' have been searched, 
 but none of them have been found:
 %s`
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -356,7 +356,7 @@ Unable to find %s programs (%s, etc...)
 These program names are provided in the config.yaml, section %s.%s.bins
 The following %s programs for the component '%s' have been search, 
 but none of them have been found:
-  %s`
+%s`
 
 	componentRoleName := "control plane"
 	componentPrograms := "apiserver, controllermanager"
@@ -370,7 +370,7 @@ but none of them have been found:
 
 	binList := ""
 	for _, bin := range bins {
-		binList = fmt.Sprintf("\t- %s\n", bin)
+		binList = fmt.Sprintf("%s\t- %s\n", binList, bin)
 	}
 
 	return fmt.Errorf(errTemplate, componentRoleName, componentPrograms, componentType, component, componentRoleName, component, binList)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -36,7 +36,7 @@ var TypeMap = map[string][]string{
 }
 
 var errMissingKubectlKubelet = fmt.Errorf(`Unable to find the programs kubectl or kubelet in the PATH.
-These programs are used to determine version of kubernetes.
+These programs are used to determine which version of Kubernetes is running.
 Make sure the /usr/bin directory is mapped to the container, 
 either using the job.yaml file used, or docker command.
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -282,7 +282,11 @@ func getKubeVersion() (string, error) {
 			if err == nil {
 				return getVersionFromKubeletOutput(string(out)), nil
 			}
-			return "", fmt.Errorf("need kubectl or kubelet binaries to get kubernetes version")
+			return "", fmt.Errorf(`Unable to find the programs (kubectl/kubelet) in the PATH.
+			These programs are used to determine version of kubernetes.
+			Take a look at our troubleshooting document for help:
+				<TROUBLESHOOT_DOC_LINK> 
+			`)
 		}
 		return getKubeVersionFromKubelet(), nil
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -38,7 +38,7 @@ var TypeMap = map[string][]string{
 var errMissingKubectlKubelet = fmt.Errorf(`Unable to find the programs kubectl or kubelet in the PATH.
 These programs are used to determine which version of Kubernetes is running.
 Make sure the /usr/bin directory is mapped to the container, 
-either using the job.yaml file used, or docker command.
+either in the job.yaml file, or Docker command.
 
 For job.yaml:
 ...

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -366,7 +366,7 @@ func makeSubstitutions(s string, ext string, m map[string]string) string {
 func buildComponentMissingErrorMessage(nodetype check.NodeType, component string, bins []string) error {
 
 	errTemplate := `
-Unable to find %s programs (%s, etc...)
+Unable to detect running executable for component %s
 These program names are provided in the config.yaml, section %s.%s.bins
 The following %s programs for the component '%s' have been searched, 
 but none of them have been found:

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -372,7 +372,7 @@ The following %s programs for the component '%s' have been searched,
 but none of them have been found:
 %s`
 
-	componentRoleName := "control plane"
+	componentRoleName := "master node"
 	componentPrograms := "apiserver, controllermanager"
 	componentType := "master"
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -35,6 +35,24 @@ var TypeMap = map[string][]string{
 	"config":     []string{"confs", "defaultconf"},
 }
 
+var errMissingKubectlKubelet = fmt.Errorf(`Unable to find the programs kubectl or kubelet in the PATH.
+These programs are used to determine version of kubernetes.
+Make sure the /usr/bin directory is mapped to the container, 
+either using the job.yaml file used, or docker command.
+
+For job.yaml:
+...
+- name: usr-bin
+  mountPath: /usr/bin
+...
+
+For docker command:
+   docker -v $(which kubectl):/usr/bin/kubectl ....
+
+Alternatively, you can specify the version with --version
+   kube-bench --version <VERSION> ...
+`)
+
 func init() {
 	psFunc = ps
 	statFunc = os.Stat
@@ -282,11 +300,7 @@ func getKubeVersion() (string, error) {
 			if err == nil {
 				return getVersionFromKubeletOutput(string(out)), nil
 			}
-			return "", fmt.Errorf(`Unable to find the programs (kubectl/kubelet) in the PATH.
-			These programs are used to determine version of kubernetes.
-			Take a look at our troubleshooting document for help:
-				<TROUBLESHOOT_DOC_LINK> 
-			`)
+			return "", errMissingKubectlKubelet
 		}
 		return getKubeVersionFromKubelet(), nil
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -35,8 +35,6 @@ var TypeMap = map[string][]string{
 	"config":     []string{"confs", "defaultconf"},
 }
 
-var errMissingKubectlKubelet = fmt.Errorf(`unable to find the programs kubectl or kubelet in the PATH`)
-
 func init() {
 	psFunc = ps
 	statFunc = os.Stat
@@ -306,7 +304,7 @@ func getKubeVersion() (string, error) {
 			}
 
 			glog.Warning(missingKubectlKubeletMessage)
-			return "", errMissingKubectlKubelet
+			return "", fmt.Errorf("unable to find the programs kubectl or kubelet in the PATH")
 		}
 		return getKubeVersionFromKubelet(), nil
 	}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/viper"
 )
 
@@ -166,7 +167,7 @@ func TestGetBinaries(t *testing.T) {
 			for k, val := range c.config {
 				v.Set(k, val)
 			}
-			m, err := getBinaries(v)
+			m, err := getBinaries(v, check.MASTER)
 			if c.expectErr {
 				if err == nil {
 					t.Fatal("Got nil Expected error")


### PR DESCRIPTION
Fixes Issue #331.

- When **kubectl** and **kubelet** are missing, the following error is displayed:

  ``` 
   Version check failed:  
    Unable to find the programs kubectl or kubelet in the PATH.
    These programs are used to determine version of kubernetes.
    Make sure the /usr/bin directory is mapped to the container,
    either using the job.yaml file used, or docker command.

    For job.yaml:
    ...
    - name: usr-bin
       mountPath: /usr/bin
    ...

    For docker command:
         docker -v $(which kubectl):/usr/bin/kubectl ....

    Alternatively, you can specify the version with --version
         kube-bench --version <VERSION> ...


- When component programs are missing, the following error is displayed:

   ```
   Unable to find control plane programs (apiserver, controllermanager, etc...)
   These program names are provided in the config.yaml, section master.apiserver.bins
   The following control plane programs for the component 'apiserver' have been search,
    but none of them have been found:
	  - kube-apiserver
	  - hyperkube apiserver
	  - hyperkube kube-apiserver
	  - apiserver
   ```


