### PR TITLE
Add run subcommand 

### DIFF
--- a/cmd/master.go
+++ b/cmd/master.go
@@ -25,7 +25,8 @@ var masterCmd = &cobra.Command{
 	Short: "Run Kubernetes benchmark checks from the master.yaml file.",
 	Long:  `Run Kubernetes benchmark checks from the master.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		runChecks(check.MASTER)
+		filename := loadConfig(check.MASTER)
+		runChecks(check.MASTER, filename)
 	},
 }
 

--- a/cmd/master.go
+++ b/cmd/master.go
@@ -1,4 +1,4 @@
-// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+// Copyright © 2017-2019 Aqua Security Software Ltd. <info@aquasec.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import (
 // masterCmd represents the master command
 var masterCmd = &cobra.Command{
 	Use:   "master",
-	Short: "Run benchmark checks for a Kubernetes master node.",
-	Long:  `Run benchmark checks for a Kubernetes master node.`,
+	Short: "Run Kubernetes benchmark checks from the master.yaml file.",
+	Long:  `Run Kubernetes benchmark checks from the master.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runChecks(check.MASTER)
 	},

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -25,7 +25,8 @@ var nodeCmd = &cobra.Command{
 	Short: "Run Kubernetes benchmark checks from the node.yaml file.",
 	Long:  `Run Kubernetes benchmark checks from the node.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		runChecks(check.NODE)
+		filename := loadConfig(check.NODE)
+		runChecks(check.NODE, filename)
 	},
 }
 

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -1,4 +1,4 @@
-// Copyright © 2017 Aqua Security Software Ltd. <info@aquasec.com>
+// Copyright © 2017-2019 Aqua Security Software Ltd. <info@aquasec.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import (
 // nodeCmd represents the node command
 var nodeCmd = &cobra.Command{
 	Use:   "node",
-	Short: "Run benchmark checks for a Kubernetes node.",
-	Long:  `Run benchmark checks for a Kubernetes node.`,
+	Short: "Run Kubernetes benchmark checks from the node.yaml file.",
+	Long:  `Run Kubernetes benchmark checks from the node.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runChecks(check.NODE)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,10 +61,12 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if isMaster() {
 			glog.V(1).Info("== Running master checks ==\n")
-			runChecks(check.MASTER)
+			filename := loadConfig(check.MASTER)
+			runChecks(check.MASTER, filename)
 		}
 		glog.V(1).Info("== Running node checks ==\n")
-		runChecks(check.NODE)
+		filename := loadConfig(check.NODE)
+		runChecks(check.NODE, filename)
 	},
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	RootCmd.AddCommand(runCmd)
+	runCmd.Flags().StringSliceP("sections", "s", []string{},
+		`Specify sections of the benchmark to run. These names need to match the filenames in the cfg/<version> directory.
+	For example, to run the tests specified in master.yaml and etcd.yaml, specify --sections=master,etcd 
+	If no sections are specified, run tests from all files in the cfg/<version> directory.
+	`)
+}
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run tests",
+	Long:  `Run tests. If no arguments are specified, runs tests from all files`,
+	Run: func(cmd *cobra.Command, args []string) {
+		sections, err := cmd.Flags().GetStringSlice("sections")
+		if err != nil {
+			exitWithError(err)
+		}
+
+		benchmarkVersion, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
+		if err != nil {
+			exitWithError(err)
+		}
+
+		err = run(sections, benchmarkVersion)
+		if err != nil {
+			fmt.Printf("Error in run: %v\n", err)
+		}
+	},
+}
+
+func run(sections []string, benchmarkVersion string) (err error) {
+
+	yamlFiles, err := getTestYamlFiles(sections, benchmarkVersion)
+	if err != nil {
+		return err
+	}
+
+	glog.V(3).Infof("Running tests from files %v\n", yamlFiles)
+
+	return nil
+}
+
+func getTestYamlFiles(sections []string, benchmarkVersion string) (yamlFiles []string, err error) {
+
+	// Check that the specified sections have corresponding YAML files in the config directory
+	configFileDirectory := filepath.Join(cfgDir, benchmarkVersion)
+	for _, section := range sections {
+		filename := section + ".yaml"
+		file := filepath.Join(configFileDirectory, filename)
+		if _, err := os.Stat(file); err != nil {
+			return nil, fmt.Errorf("file %s not found for version %s", filename, benchmarkVersion)
+		}
+		yamlFiles = append(yamlFiles, filename)
+	}
+
+	// If no sections were specified, we will run tests from all the files in the directory
+	if len(yamlFiles) == 0 {
+		yamlFiles, err = getYamlFilesFromDir(configFileDirectory)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return yamlFiles, err
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetTestYamlFiles(t *testing.T) {
+	cases := []struct {
+		name      string
+		sections  []string
+		benchmark string
+		succeed   bool
+		expCount  int
+	}{
+		{
+			name:      "Specify two sections",
+			sections:  []string{"one", "two"},
+			benchmark: "benchmark",
+			succeed:   true,
+			expCount:  2,
+		},
+		{
+			name:      "Specify a section that doesn't exist",
+			sections:  []string{"one", "missing"},
+			benchmark: "benchmark",
+			succeed:   false,
+		},
+		{
+			name:      "No sections specified - should return everything except config.yaml",
+			sections:  []string{},
+			benchmark: "benchmark",
+			succeed:   true,
+			expCount:  3,
+		},
+		{
+			name:      "Specify benchmark that doesn't exist",
+			sections:  []string{"one"},
+			benchmark: "missing",
+			succeed:   false,
+		},
+	}
+
+	// Set up temp config directory
+	var err error
+	cfgDir, err = ioutil.TempDir("", "kube-bench-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory")
+	}
+	defer os.RemoveAll(cfgDir)
+
+	d := filepath.Join(cfgDir, "benchmark")
+	err = os.Mkdir(d, 0766)
+	if err != nil {
+		t.Fatalf("Failed to create temp dir")
+	}
+
+	// We never expect config.yaml to be returned
+	for _, filename := range []string{"one.yaml", "two.yaml", "three.yaml", "config.yaml"} {
+		err = ioutil.WriteFile(filepath.Join(d, filename), []byte("hello world"), 0666)
+		if err != nil {
+			t.Fatalf("error writing temp file %s: %v", filename, err)
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			yamlFiles, err := getTestYamlFiles(c.sections, c.benchmark)
+			if err != nil && c.succeed {
+				t.Fatalf("Error %v", err)
+			}
+
+			if err == nil && !c.succeed {
+				t.Fatalf("Expected failure")
+			}
+
+			if len(yamlFiles) != c.expCount {
+				t.Fatalf("Expected %d, got %d", c.expCount, len(yamlFiles))
+			}
+		})
+	}
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -131,7 +131,7 @@ func getConfigFilePath(benchmarkVersion string, filename string) (path string, e
 	file := filepath.Join(path, string(filename))
 	glog.V(2).Info(fmt.Sprintf("Looking for config file: %s", file))
 
-	if _, err = os.Stat(file); os.IsNotExist(err) {
+	if _, err := os.Stat(file); err != nil {
 		glog.V(2).Infof("error accessing config file: %q error: %v\n", file, err)
 		return "", fmt.Errorf("no test files found <= benchmark version: %s", benchmarkVersion)
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -123,19 +123,37 @@ func getBinaries(v *viper.Viper, nodetype check.NodeType) (map[string]string, er
 	return binmap, nil
 }
 
-// getConfigFilePath locates the config files we should be using CIS version
+// getConfigFilePath locates the config files we should be using for CIS version
 func getConfigFilePath(benchmarkVersion string, filename string) (path string, err error) {
 	glog.V(2).Info(fmt.Sprintf("Looking for config specific CIS version %q", benchmarkVersion))
 
 	path = filepath.Join(cfgDir, benchmarkVersion)
 	file := filepath.Join(path, string(filename))
-	glog.V(2).Info(fmt.Sprintf("Looking for config file: %s", file))
+	glog.V(2).Info(fmt.Sprintf("Looking for file: %s", file))
 
 	if _, err := os.Stat(file); err != nil {
 		glog.V(2).Infof("error accessing config file: %q error: %v\n", file, err)
 		return "", fmt.Errorf("no test files found <= benchmark version: %s", benchmarkVersion)
 	}
+
 	return path, nil
+}
+
+// getYamlFilesFromDir returns a list of yaml files in the specified directory, ignoring config.yaml
+func getYamlFilesFromDir(path string) (names []string, err error) {
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		_, name := filepath.Split(path)
+		if name != "" && name != "config.yaml" && filepath.Ext(name) == ".yaml" {
+			names = append(names, name)
+		}
+
+		return nil
+	})
+	return names, err
 }
 
 // decrementVersion decrements the version number

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -148,7 +148,7 @@ func getYamlFilesFromDir(path string) (names []string, err error) {
 
 		_, name := filepath.Split(path)
 		if name != "" && name != "config.yaml" && filepath.Ext(name) == ".yaml" {
-			names = append(names, name)
+			names = append(names, path)
 		}
 
 		return nil

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -505,7 +505,7 @@ func TestGetYamlFilesFromDir(t *testing.T) {
 		t.Fatalf("Expected to find one file, found %d", len(files))
 	}
 
-	if files[0] != "something.yaml" {
+	if files[0] != filepath.Join(d, "something.yaml") {
 		t.Fatalf("Expected to find something.yaml, found %s", files[0])
 	}
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -474,3 +474,38 @@ func TestDecrementVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestGetYamlFilesFromDir(t *testing.T) {
+	cfgDir, err := ioutil.TempDir("", "kube-bench-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory")
+	}
+	defer os.RemoveAll(cfgDir)
+
+	d := filepath.Join(cfgDir, "cis-1.4")
+	err = os.Mkdir(d, 0766)
+	if err != nil {
+		t.Fatalf("Failed to create temp dir")
+	}
+
+	err = ioutil.WriteFile(filepath.Join(d, "something.yaml"), []byte("hello world"), 0666)
+	if err != nil {
+		t.Fatalf("error writing file %v", err)
+	}
+	err = ioutil.WriteFile(filepath.Join(d, "config.yaml"), []byte("hello world"), 0666)
+	if err != nil {
+		t.Fatalf("error writing file %v", err)
+	}
+
+	files, err := getYamlFilesFromDir(d)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("Expected to find one file, found %d", len(files))
+	}
+
+	if files[0] != "something.yaml" {
+		t.Fatalf("Expected to find something.yaml, found %s", files[0])
+	}
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -410,11 +410,14 @@ func TestGetConfigFilePath(t *testing.T) {
 	}
 	defer os.RemoveAll(cfgDir)
 	d := filepath.Join(cfgDir, "cis-1.4")
-	err = os.Mkdir(d, 0666)
+	err = os.Mkdir(d, 0766)
 	if err != nil {
-		t.Fatalf("Failed to create temp file")
+		t.Fatalf("Failed to create temp dir")
 	}
-	ioutil.WriteFile(filepath.Join(d, "master.yaml"), []byte("hello world"), 0666)
+	err = ioutil.WriteFile(filepath.Join(d, "master.yaml"), []byte("hello world"), 0666)
+	if err != nil {
+		t.Logf("Failed to create temp file")
+	}
 
 	cases := []struct {
 		benchmarkVersion string


### PR DESCRIPTION
Adds `run` subcommand to partially cover what is discussed [here](https://github.com/aquasecurity/kube-bench/issues/494#issuecomment-559183325)

This works with the existing config files as follows:

* `kube-bench run` is equivalent to `kube-bench`
* `kube-bench run --sections master,node` is also equivalent to `kube-bench` 
* `kube-bench run --sections master` is equivalent to `kube-bench master`
* `kube-bench run --sections node` is equivalent to `kube-bench node`

I think that when we have new section files for CIS 1.5 we will be able to run, for example `kube-bench run --sections etcd` to run the tests in the etcd file. However, there will need to be settings in the `config.yaml` file(s) to cover `etcd` (just as we currently need settings for `master` and `node`. 

This PR does not attempt to do the auto-detection part described in the proposal in #494 