### PR TITLE
added 444, 440, 400 and 000 file permission checks for all benchmarks

### DIFF
--- a/cfg/cis-1.3/master.yaml
+++ b/cfg/cis-1.3/master.yaml
@@ -857,6 +857,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -901,6 +921,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -947,6 +987,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -991,6 +1051,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -1094,6 +1174,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -1138,6 +1238,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node. For example, chmod 644 /etc/kubernetes/scheduler.conf
@@ -1179,6 +1299,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the

--- a/cfg/cis-1.3/node.yaml
+++ b/cfg/cis-1.3/node.yaml
@@ -362,20 +362,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -405,20 +425,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -445,20 +485,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -520,20 +580,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the following command (using the config file location identied in the Audit step)

--- a/cfg/cis-1.4/master.yaml
+++ b/cfg/cis-1.4/master.yaml
@@ -859,6 +859,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -903,6 +923,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -949,6 +989,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -993,6 +1053,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -1096,6 +1176,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -1140,6 +1240,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node. For example, chmod 644 /etc/kubernetes/scheduler.conf
@@ -1181,6 +1301,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
@@ -1240,6 +1380,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           [Manual test]

--- a/cfg/cis-1.4/node.yaml
+++ b/cfg/cis-1.4/node.yaml
@@ -345,20 +345,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -388,20 +408,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -428,20 +468,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker
@@ -521,20 +581,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the following command (using the config file location identied in the Audit step)

--- a/cfg/cis-1.5/master.yaml
+++ b/cfg/cis-1.5/master.yaml
@@ -29,6 +29,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node.
@@ -71,6 +91,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -115,6 +155,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -157,6 +217,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
@@ -253,6 +333,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -296,6 +396,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -338,6 +458,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -14,20 +14,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
@@ -54,20 +74,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
@@ -93,20 +133,40 @@ groups:
         tests:
           test_items:
             - flag: "644"
-              set: true
               compare:
                 op: eq
                 value: "644"
-            - flag: "640"
               set: true
+            - flag: "640"
               compare:
                 op: eq
                 value: "640"
-            - flag: "600"
               set: true
+            - flag: "600"
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
@@ -173,6 +233,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
           bin_op: or
         remediation: |
           Run the following command (using the config file location identied in the Audit step)

--- a/cfg/rh-0.7/master.yaml
+++ b/cfg/rh-0.7/master.yaml
@@ -962,6 +962,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command.
 
@@ -1039,6 +1059,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command.
 
@@ -1082,6 +1122,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command.
 
@@ -1124,6 +1184,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command.

--- a/cfg/rh-0.7/node.yaml
+++ b/cfg/rh-0.7/node.yaml
@@ -232,6 +232,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command on each worker node.
           chmod 644 /etc/origin/node/node.kubeconfig
@@ -272,6 +292,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command on each worker node.
@@ -314,6 +354,26 @@ groups:
                 op: eq
                 value: "600"
               set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
         remediation: |
           Run the below command on each worker node.
           chmod 644 /etc/origin/node/node.kubeconfig
@@ -354,6 +414,26 @@ groups:
               compare:
                 op: eq
                 value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
               set: true
         remediation: |
           Run the below command on each worker node.


### PR DESCRIPTION
Fixes #541 

Additionally the format of all file permissions checks was streamlined. Some of the config files had the order of the keys different, now the order is the same for all configs. 