### PR TITLE
FIX : Resolved bug in related to apiserverbin variable name in check 1.2.21

### DIFF
--- a/cfg/cis-1.5/master.yaml
+++ b/cfg/cis-1.5/master.yaml
@@ -734,7 +734,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --profiling argument is set to false (Scored)"
-        audit: "/bin/ps -ef | grep $apiserver | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--profiling"
@@ -963,7 +963,7 @@ groups:
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         scored: false
 
   - id: 1.3


### PR DESCRIPTION
Resolved bug in **master.yml** for **cis-1.5** for the **$apiserverbin** variable name in check **1.2.21**
For check **1.2.21**, a wrong variable name is referenced **$apiserver** which actually should be **$apiserverbin**
This was making check to fail even if the **profiling** argument is set to **false** for **apiserver**
Also resolved remediation description which din't list all the required **tls-cipher-suites** which are actually checked in the check **1.2.35**