### PR TITLE
Set all host-mounted volumes to be read-only.

### DIFF
--- a/job-eks.yaml
+++ b/job-eks.yaml
@@ -15,10 +15,13 @@ spec:
           volumeMounts:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
+              readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-kubelet

--- a/job-iks.yaml
+++ b/job-iks.yaml
@@ -14,10 +14,13 @@ spec:
           volumeMounts:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
+              readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-kubelet

--- a/job-master.yaml
+++ b/job-master.yaml
@@ -20,12 +20,15 @@ spec:
           volumeMounts:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
+              readOnly: true
               # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
               # You can omit this mount if you specify --version as part of the command.
             - name: usr-bin
               mountPath: /usr/bin
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-etcd

--- a/job-node.yaml
+++ b/job-node.yaml
@@ -14,14 +14,18 @@ spec:
           volumeMounts:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
+              readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
+              readOnly: true
               # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
               # You can omit this mount if you specify --version as part of the command.
             - name: usr-bin
               mountPath: /usr/bin
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-kubelet

--- a/job.yaml
+++ b/job.yaml
@@ -17,16 +17,21 @@ spec:
           volumeMounts:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd
+              readOnly: true
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
+              readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
+              readOnly: true
               # /usr/bin is mounted to access kubectl / kubelet, for auto-detecting the Kubernetes version.
               # You can omit this mount if you specify --version as part of the command.
             - name: usr-bin
               mountPath: /usr/bin
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-etcd


### PR DESCRIPTION
By setting all host-mounted volumes to be read-only we reduce the likelihood
any host filesystem is modified by running kube-bench. This is a defense in depth measure that improves confidence in running kube-bench in production environments as well as allowing kube-bench to run where restrictive pod security policies are enforced.