### PR TITLE
docs: CIS benchmarks are not frequent

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ No tests will be run for this check and the output will be marked [INFO].
 
 ## Roadmap
 
-Going forward we plan to release updates to kube-bench to add support for new releases of the Benchmark, which in turn we can anticipate being made for each new Kubernetes release.
+Going forward we plan to release updates to kube-bench to add support for new releases of the CIS Benchmark. Note that these are not released as frequently as Kubernetes releases. 
 
 We welcome PRs and issue reports.
 


### PR DESCRIPTION
Correct misleading comment about anticipated CIS benchmarks for every Kubernetes release - bad assumption!