### PR TITLE
Fix misspelling - identied / identified in remediation section of node.yaml

### DIFF
--- a/cfg/cis-1.3/node.yaml
+++ b/cfg/cis-1.3/node.yaml
@@ -477,7 +477,7 @@ groups:
             - flag: root:root
               set: true
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
 
@@ -492,6 +492,6 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
         scored: true

--- a/cfg/cis-1.4/node.yaml
+++ b/cfg/cis-1.4/node.yaml
@@ -468,7 +468,7 @@ groups:
             - flag: root:root
               set: true
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
 
@@ -483,6 +483,6 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
         scored: true

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -131,7 +131,7 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
         scored: true
 
@@ -143,7 +143,7 @@ groups:
             - flag: root:root
               set: true
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
 

--- a/cfg/gke-1.0/node.yaml
+++ b/cfg/gke-1.0/node.yaml
@@ -139,7 +139,7 @@ groups:
               set: true
           bin_op: or
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
         scored: true
 
@@ -151,7 +151,7 @@ groups:
             - flag: root:root
               set: true
         remediation: |
-          Run the following command (using the config file location identied in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
 


### PR DESCRIPTION
Fixed the common misspelling of "identied" instead of "identified" in the remediation instructions for CIS and GKE benchmark nodes.

- cfg/cis-1.3/node.yaml
- cfg/cis-1.4/node.yaml 
- cfg/cis-1.5/node.yaml
- cfg/gke-1.0/node.yaml 
