### PR TITLE
.goreleaser: Create binaries for arm/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,11 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
     ldflags:
       - "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion={{.Version}}"
       - "-X github.com/aquasecurity/kube-bench/cmd.cfgDir={{.Env.KUBEBENCH_CFG}}"
@@ -16,6 +21,7 @@ builds:
 archives:
   - id: default
     format: tar.gz
+    name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{.Arm }}{{ end }}'
     files:
       - "cfg/**/*"
 nfpms:


### PR DESCRIPTION
This creates binaries for arm/amd64 that would show up on a release, so users could pull the binary and drop it into a container.

Partially fixes https://github.com/aquasecurity/kube-bench/issues/627