### PR TITLE
make the kubelet cafile test posix compliant

### DIFF
--- a/cfg/cis-1.3/node.yaml
+++ b/cfg/cis-1.3/node.yaml
@@ -458,9 +458,7 @@ groups:
         text: Ensure that the client certificate authorities file ownership is set to root:root (Scored)
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if [[ -z $CAFILE ]]; then
-            CAFILE=$kubeletcafile
-          fi
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:
           test_items:

--- a/cfg/cis-1.4/node.yaml
+++ b/cfg/cis-1.4/node.yaml
@@ -449,9 +449,7 @@ groups:
         text: Ensure that the client certificate authorities file ownership is set to root:root (Scored)
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if [[ -z $CAFILE ]]; then
-            CAFILE=$kubeletcafile
-          fi
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:
           test_items:

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -109,9 +109,7 @@ groups:
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if [[ -z $CAFILE ]]; then
-            CAFILE=$kubeletcafile
-          fi
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:
           test_items:


### PR DESCRIPTION
Fixes #642 by making the test posix compliant.