### PR TITLE
Warn if kubectl can't autodetect the version 

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -191,7 +191,7 @@ func prettyPrint(r *check.Controls, summary check.Summary) {
 // loadConfig finds the correct config dir based on the kubernetes version,
 // merges any specific config.yaml file found with the main config
 // and returns the benchmark file to use.
-func loadConfig(nodetype check.NodeType) string {
+func loadConfig(nodetype check.NodeType, benchmarkVersion string) string {
 	var file string
 	var err error
 
@@ -208,11 +208,6 @@ func loadConfig(nodetype check.NodeType) string {
 		file = policiesFile
 	case check.MANAGEDSERVICES:
 		file = managedservicesFile
-	}
-
-	benchmarkVersion, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
-	if err != nil {
-		exitWithError(fmt.Errorf("failed to get benchMark version: %v", err))
 	}
 
 	path, err := getConfigFilePath(benchmarkVersion, file)
@@ -302,7 +297,6 @@ func getBenchmarkVersion(kubeVersion, benchmarkVersion string, v *viper.Viper) (
 
 // isMaster verify if master components are running on the node.
 func isMaster() bool {
-	loadConfig(check.MASTER)
 	return isThisNodeRunning(check.MASTER)
 }
 

--- a/cmd/master.go
+++ b/cmd/master.go
@@ -15,8 +15,11 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // masterCmd represents the master command
@@ -25,7 +28,12 @@ var masterCmd = &cobra.Command{
 	Short: "Run Kubernetes benchmark checks from the master.yaml file.",
 	Long:  `Run Kubernetes benchmark checks from the master.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		filename := loadConfig(check.MASTER)
+		bv, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
+		if err != nil {
+			exitWithError(fmt.Errorf("unable to determine benchmark version: %v", err))
+		}
+
+		filename := loadConfig(check.MASTER, bv)
 		runChecks(check.MASTER, filename)
 		writeOutput(controlsCollection)
 	},

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -15,8 +15,11 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // nodeCmd represents the node command
@@ -25,7 +28,12 @@ var nodeCmd = &cobra.Command{
 	Short: "Run Kubernetes benchmark checks from the node.yaml file.",
 	Long:  `Run Kubernetes benchmark checks from the node.yaml file in cfg/<version>.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		filename := loadConfig(check.NODE)
+		bv, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
+		if err != nil {
+			exitWithError(fmt.Errorf("unable to determine benchmark version: %v", err))
+		}
+
+		filename := loadConfig(check.NODE, bv)
 		runChecks(check.NODE, filename)
 		writeOutput(controlsCollection)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,45 +64,45 @@ var RootCmd = &cobra.Command{
 	Short: "Run CIS Benchmarks checks against a Kubernetes deployment",
 	Long:  `This tool runs the CIS Kubernetes Benchmark (https://www.cisecurity.org/benchmark/kubernetes/)`,
 	Run: func(cmd *cobra.Command, args []string) {
-		benchmarkVersion, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
+		bv, err := getBenchmarkVersion(kubeVersion, benchmarkVersion, viper.GetViper())
 		if err != nil {
 			exitWithError(fmt.Errorf("unable to determine benchmark version: %v", err))
 		}
 
 		if isMaster() {
 			glog.V(1).Info("== Running master checks ==\n")
-			runChecks(check.MASTER, loadConfig(check.MASTER))
+			runChecks(check.MASTER, loadConfig(check.MASTER, bv))
 
 			// Control Plane is only valid for CIS 1.5 and later,
 			// this a gatekeeper for previous versions
-			if validTargets(benchmarkVersion, []string{string(check.CONTROLPLANE)}) {
+			if validTargets(bv, []string{string(check.CONTROLPLANE)}) {
 				glog.V(1).Info("== Running control plane checks ==\n")
-				runChecks(check.CONTROLPLANE, loadConfig(check.CONTROLPLANE))
+				runChecks(check.CONTROLPLANE, loadConfig(check.CONTROLPLANE, bv))
 			}
 		}
 
 		// Etcd is only valid for CIS 1.5 and later,
 		// this a gatekeeper for previous versions.
-		if validTargets(benchmarkVersion, []string{string(check.ETCD)}) && isEtcd() {
+		if validTargets(bv, []string{string(check.ETCD)}) && isEtcd() {
 			glog.V(1).Info("== Running etcd checks ==\n")
-			runChecks(check.ETCD, loadConfig(check.ETCD))
+			runChecks(check.ETCD, loadConfig(check.ETCD, bv))
 		}
 
 		glog.V(1).Info("== Running node checks ==\n")
-		runChecks(check.NODE, loadConfig(check.NODE))
+		runChecks(check.NODE, loadConfig(check.NODE, bv))
 
 		// Policies is only valid for CIS 1.5 and later,
 		// this a gatekeeper for previous versions.
-		if validTargets(benchmarkVersion, []string{string(check.POLICIES)}) {
+		if validTargets(bv, []string{string(check.POLICIES)}) {
 			glog.V(1).Info("== Running policies checks ==\n")
-			runChecks(check.POLICIES, loadConfig(check.POLICIES))
+			runChecks(check.POLICIES, loadConfig(check.POLICIES, bv))
 		}
 
 		// Managedservices is only valid for GKE 1.0 and later,
 		// this a gatekeeper for previous versions.
-		if validTargets(benchmarkVersion, []string{string(check.MANAGEDSERVICES)}) {
+		if validTargets(bv, []string{string(check.MANAGEDSERVICES)}) {
 			glog.V(1).Info("== Running managed services checks ==\n")
-			runChecks(check.MANAGEDSERVICES, loadConfig(check.MANAGEDSERVICES))
+			runChecks(check.MANAGEDSERVICES, loadConfig(check.MANAGEDSERVICES, bv))
 		}
 
 		writeOutput(controlsCollection)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -276,7 +276,7 @@ func multiWordReplace(s string, subname string, sub string) string {
 const missingKubectlKubeletMessage = `
 Unable to find the programs kubectl or kubelet in the PATH.
 These programs are used to determine which version of Kubernetes is running.
-Make sure the /usr/local/mount-from-host/bin directory is mapped to the container, 
+Make sure the /usr/local/mount-from-host/bin directory is mapped to the container,
 either in the job.yaml file, or Docker command.
 
 For job.yaml:
@@ -346,6 +346,9 @@ func getVersionFromKubectlOutput(s string) string {
 	serverVersionRe := regexp.MustCompile(`Server Version: v(\d+.\d+)`)
 	subs := serverVersionRe.FindStringSubmatch(s)
 	if len(subs) < 2 {
+		if strings.Contains(s, "The connection to the server") {
+			continueWithError(nil, `Warning: Kubernetes version was not auto-detected because kubectl could not connect to the Kubernetes server. This may be because the kubeconfig information is missing or has credentials that do not match the server.`)
+		}
 		glog.V(1).Info(fmt.Sprintf("Unable to get Kubernetes version from kubectl, using default version: %s", defaultKubeVersion))
 		return defaultKubeVersion
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -347,7 +347,8 @@ func getVersionFromKubectlOutput(s string) string {
 	subs := serverVersionRe.FindStringSubmatch(s)
 	if len(subs) < 2 {
 		if strings.Contains(s, "The connection to the server") {
-			continueWithError(nil, `Warning: Kubernetes version was not auto-detected because kubectl could not connect to the Kubernetes server. This may be because the kubeconfig information is missing or has credentials that do not match the server.`)
+			msg := fmt.Sprintf(`Warning: Kubernetes version was not auto-detected because kubectl could not connect to the Kubernetes server. This may be because the kubeconfig information is missing or has credentials that do not match the server. Assuming default version %s`, defaultKubeVersion)
+			fmt.Fprintln(os.Stderr, msg)
 		}
 		glog.V(1).Info(fmt.Sprintf("Unable to get Kubernetes version from kubectl, using default version: %s", defaultKubeVersion))
 		return defaultKubeVersion


### PR DESCRIPTION
See #655. This outputs a warning if kubectl doesn't have access to kubeconfig and can't autodetect the version. 

Modified code to only run `getBenchmarkVersion()` once per command, so that this new warning doesn't get emitted four times! (Note that the `loadConfig()` function can get called several times from the code in root.go) 

This PR doesn't update the default version yet so it's not a full fix for the issue. 