### PR TITLE
Better handling of parameters and config audits

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,8 @@
+---
 blank_issues_enabled: false
 contact_links:
   - name: Feature request
-    url: https://github.com/aquasecurity/kube-bench/discussions/new?category_id=19113743    
+    url: https://github.com/aquasecurity/kube-bench/discussions/new?category_id=19113743
     about: Share ideas for new features
   - name: Ask a question
     url: https://github.com/aquasecurity/kube-bench/discussions/new?category_id=19113742

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -236,6 +236,7 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
+          bin_op: or
           test_items:
             - flag: "--read-only-port"
               path: '{.readOnlyPort}'
@@ -243,6 +244,8 @@ groups:
               compare:
                 op: eq
                 value: 0
+            - path: '{.readOnlyPort}'
+              set: false
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.
           If using command line arguments, edit the kubelet service file

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -244,7 +244,8 @@ groups:
               compare:
                 op: eq
                 value: 0
-            - path: '{.readOnlyPort}'
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
               set: false
         remediation: |
           If using a Kubelet config file, edit the file to set readOnlyPort to 0.

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -150,6 +150,10 @@ func TestCheckAuditConfig(t *testing.T) {
 			controls.Groups[1].Checks[15],
 			"PASS",
 		},
+		{
+			controls.Groups[1].Checks[16],
+			"FAIL",
+		},
 	}
 
 	for _, c := range cases {

--- a/check/data
+++ b/check/data
@@ -502,7 +502,8 @@ groups:
             compare:
               op: eq
               value: 0
-          - path: '{.readOnlyPort}'
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
             set: false
       scored: true
     - id: 14
@@ -518,7 +519,8 @@ groups:
             compare:
               op: eq
               value: 0
-          - path: '{.readOnlyPort}'
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
             set: false
       scored: true
     - id: 15
@@ -534,6 +536,24 @@ groups:
             compare:
               op: eq
               value: 0
-          - path: '{.readOnlyPort}'
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
+            set: false
+      scored: true
+    - id: 15
+      text: "parameter and config file don't have same default - parameter has bad value and config is not present - failing"
+      audit: "echo '--read-only-port=1'"
+      audit_config: "echo ''"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
+            set: true
+            compare:
+              op: eq
+              value: 0
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
             set: false
       scored: true

--- a/check/data
+++ b/check/data
@@ -166,7 +166,7 @@ groups:
               op: eq
               value: some-val
             set: true
-            
+
     - id: 15
       text: "jsonpath correct value on field"
       tests:
@@ -475,4 +475,65 @@ groups:
               op: bitmask
               value: "600"
             set: true
+      scored: true
+    - id: 12
+      text: "audit is present and wrong, audit_config is right -> fail (command line parameters override config file)"
+      audit: "echo flag=wrong"
+      audit_config: "echo 'flag: correct'"
+      tests:
+        test_items:
+          - flag: "flag"
+            path: "{.flag}"
+            compare:
+              op: eq
+              value: "correct"
+            set: true
+      scored: true
+    - id: 13
+      text: "parameter and config file don't have same default - parameter has failing value"
+      audit: "echo '--read-only-port=1'"
+      audit_config: "echo 'readOnlyPort: 0'"
+      tests:
+        bin_op: and
+        test_items:
+          - flag: "--read-only-port"
+            path: "{.readOnlyPort}"
+            set: true
+            compare:
+              op: eq
+              value: 0
+          - path: '{.readOnlyPort}'
+            set: false
+      scored: true
+    - id: 14
+      text: "parameter and config file don't have same default - config file has failing value"
+      audit: "echo ''"
+      audit_config: "echo 'readOnlyPort: 1'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
+            set: true
+            compare:
+              op: eq
+              value: 0
+          - path: '{.readOnlyPort}'
+            set: false
+      scored: true
+    - id: 15
+      text: "parameter and config file don't have same default - passing"
+      audit: "echo ''"
+      audit_config: "echo ''"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--read-only-port"
+            path: '{.readOnlyPort}'
+            set: true
+            compare:
+              op: eq
+              value: 0
+          - path: '{.readOnlyPort}'
+            set: false
       scored: true

--- a/check/test.go
+++ b/check/test.go
@@ -43,14 +43,24 @@ const (
 	defaultArraySeparator       = ","
 )
 
-type testItem struct {
-	Flag    string
-	Path    string
-	Output  string
-	Value   string
-	Set     bool
-	Compare compare
+type tests struct {
+	TestItems []*testItem `yaml:"test_items"`
+	BinOp     binOp       `yaml:"bin_op"`
 }
+
+type testItem struct {
+	Flag             string
+	Path             string
+	Output           string
+	Value            string
+	Set              bool
+	Compare          compare
+	isMultipleOutput bool
+	isConfigSetting  bool
+}
+
+type pathTestItem testItem
+type flagTestItem testItem
 
 type compare struct {
 	Op    string
@@ -59,6 +69,7 @@ type compare struct {
 
 type testOutput struct {
 	testResult     bool
+	flagFound      bool
 	actualResult   string
 	ExpectedResult string
 }
@@ -67,99 +78,124 @@ func failTestItem(s string) *testOutput {
 	return &testOutput{testResult: false, actualResult: s}
 }
 
-func (t *testItem) execute(s string, isMultipleOutput bool) *testOutput {
+func (t testItem) flagValue() string {
+	if t.isConfigSetting {
+		return t.Path
+	}
+
+	return t.Flag
+}
+
+func (t testItem) findValue(s string) (match bool, value string, err error) {
+	if t.isConfigSetting {
+		pt := pathTestItem(t)
+		return pt.findValue(s)
+	}
+
+	ft := flagTestItem(t)
+	return ft.findValue(s)
+}
+
+func (t flagTestItem) findValue(s string) (match bool, value string, err error) {
+	if s == "" || t.Flag == "" {
+		return
+	}
+	match = strings.Contains(s, t.Flag)
+	if match {
+		// Expects flags in the form;
+		// --flag=somevalue
+		// flag: somevalue
+		// --flag
+		// somevalue
+		pttn := `(` + t.Flag + `)(=|: *)*([^\s]*) *`
+		flagRe := regexp.MustCompile(pttn)
+		vals := flagRe.FindStringSubmatch(s)
+
+		if len(vals) > 0 {
+			if vals[3] != "" {
+				value = vals[3]
+			} else {
+				// --bool-flag
+				if strings.HasPrefix(t.Flag, "--") {
+					value = "true"
+				} else {
+					value = vals[1]
+				}
+			}
+		} else {
+			err = fmt.Errorf("invalid flag in testItem definition: %s", s)
+		}
+	}
+	glog.V(3).Infof("In flagTestItem.findValue %s, match %v, s %s, t.Flag %s", value, match, s, t.Flag)
+
+	return match, value, err
+}
+
+func (t pathTestItem) findValue(s string) (match bool, value string, err error) {
+	var jsonInterface interface{}
+
+	err = unmarshal(s, &jsonInterface)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to load YAML or JSON from input \"%s\": %v", s, err)
+	}
+
+	value, err = executeJSONPath(t.Path, &jsonInterface)
+	if err != nil {
+		return false, "", fmt.Errorf("unable to parse path expression \"%s\": %v", t.Path, err)
+	}
+
+	glog.V(3).Infof("In pathTestItem.findValue %s", value)
+	match = (value != "")
+	return match, value, err
+}
+
+func (t testItem) execute(s string) *testOutput {
 	result := &testOutput{}
 	s = strings.TrimRight(s, " \n")
 
 	// If the test has output that should be evaluated for each row
-	if isMultipleOutput {
-		output := strings.Split(s, "\n")
-		for _, op := range output {
-			result = t.evaluate(op)
-			// If the test failed for the current row, no need to keep testing for this output
-			if !result.testResult {
-				break
-			}
-		}
+	var output []string
+	if t.isMultipleOutput {
+		output = strings.Split(s, "\n")
 	} else {
-		result = t.evaluate(s)
+		output = []string{s}
+	}
+
+	for _, op := range output {
+		result = t.evaluate(op)
+		// If the test failed for the current row, no need to keep testing for this output
+		if !result.testResult {
+			break
+		}
 	}
 
 	return result
 }
 
-func (t *testItem) evaluate(s string) *testOutput {
+func (t testItem) evaluate(s string) *testOutput {
 	result := &testOutput{}
-	var match bool
-	var flagVal string
 
-	if t.Flag != "" {
-		// Flag comparison: check if the flag is present in the input
-		match = strings.Contains(s, t.Flag)
-	} else {
-		// Path != "" - we don't know whether it's YAML or JSON but
-		// we can just try one then the other
-		var jsonInterface interface{}
-
-		if t.Path != "" {
-			err := unmarshal(s, &jsonInterface)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to load YAML or JSON from provided input \"%s\": %v\n", s, err)
-				return failTestItem("failed to load YAML or JSON")
-			}
-
-		}
-
-		jsonpathResult, err := executeJSONPath(t.Path, &jsonInterface)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to parse path expression \"%s\": %v\n", t.Path, err)
-			return failTestItem("error executing path expression")
-		}
-		match = (jsonpathResult != "")
-		flagVal = jsonpathResult
+	match, value, err := t.findValue(s)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		return failTestItem(err.Error())
 	}
 
 	if t.Set {
-		isset := match
-
-		if isset && t.Compare.Op != "" {
-			if t.Flag != "" {
-				// Expects flags in the form;
-				// --flag=somevalue
-				// flag: somevalue
-				// --flag
-				// somevalue
-				pttn := `(` + t.Flag + `)(=|: *)*([^\s]*) *`
-				flagRe := regexp.MustCompile(pttn)
-				vals := flagRe.FindStringSubmatch(s)
-
-				if len(vals) > 0 {
-					if vals[3] != "" {
-						flagVal = vals[3]
-					} else {
-						// --bool-flag
-						if strings.HasPrefix(t.Flag, "--") {
-							flagVal = "true"
-						} else {
-							flagVal = vals[1]
-						}
-					}
-				} else {
-					glog.V(1).Infof(fmt.Sprintf("invalid flag in testitem definition"))
-					return failTestItem("error invalid flag in testitem definition")
-				}
-			}
-
-			result.ExpectedResult, result.testResult = compareOp(t.Compare.Op, flagVal, t.Compare.Value)
+		if match && t.Compare.Op != "" {
+			result.ExpectedResult, result.testResult = compareOp(t.Compare.Op, value, t.Compare.Value)
 		} else {
-			result.ExpectedResult = fmt.Sprintf("'%s' is present", t.Flag)
-			result.testResult = isset
+			result.ExpectedResult = fmt.Sprintf("'%s' is present", t.flagValue())
+			result.testResult = match
 		}
 	} else {
-		result.ExpectedResult = fmt.Sprintf("'%s' is not present", t.Flag)
-		notset := !match
-		result.testResult = notset
+		result.ExpectedResult = fmt.Sprintf("'%s' is not present", t.flagValue())
+		result.testResult = !match
 	}
+
+	result.flagFound = match
+	glog.V(3).Info(fmt.Sprintf("flagFound %v", result.flagFound))
+
 	return result
 }
 
@@ -324,66 +360,6 @@ func splitAndRemoveLastSeparator(s, sep string) []string {
 	}
 
 	return ts
-}
-
-type tests struct {
-	TestItems []*testItem `yaml:"test_items"`
-	BinOp     binOp       `yaml:"bin_op"`
-}
-
-func (ts *tests) execute(s string, isMultipleOutput bool) *testOutput {
-	finalOutput := &testOutput{}
-
-	// If no tests are defined return with empty finalOutput.
-	// This may be the case for checks of type: "skip".
-	if ts == nil {
-		return finalOutput
-	}
-
-	res := make([]testOutput, len(ts.TestItems))
-	if len(res) == 0 {
-		return finalOutput
-	}
-
-	expectedResultArr := make([]string, len(res))
-
-	for i, t := range ts.TestItems {
-		res[i] = *(t.execute(s, isMultipleOutput))
-		expectedResultArr[i] = res[i].ExpectedResult
-	}
-
-	var result bool
-	// If no binary operation is specified, default to AND
-	switch ts.BinOp {
-	default:
-		glog.V(2).Info(fmt.Sprintf("unknown binary operator for tests %s\n", ts.BinOp))
-		finalOutput.actualResult = fmt.Sprintf("unknown binary operator for tests %s\n", ts.BinOp)
-		return finalOutput
-	case and, "":
-		result = true
-		for i := range res {
-			result = result && res[i].testResult
-		}
-		// Generate an AND expected result
-		finalOutput.ExpectedResult = strings.Join(expectedResultArr, " AND ")
-
-	case or:
-		result = false
-		for i := range res {
-			result = result || res[i].testResult
-		}
-		// Generate an OR expected result
-		finalOutput.ExpectedResult = strings.Join(expectedResultArr, " OR ")
-	}
-
-	finalOutput.testResult = result
-	finalOutput.actualResult = res[0].actualResult
-
-	if finalOutput.actualResult == "" {
-		finalOutput.actualResult = s
-	}
-
-	return finalOutput
 }
 
 func toNumeric(a, b string) (c, d int, err error) {

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -48,143 +48,181 @@ func TestTestExecute(t *testing.T) {
 
 	cases := []struct {
 		*Check
-		str string
+		str       string
+		strConfig string
 	}{
 		{
 			controls.Groups[0].Checks[0],
 			"2:45 ../kubernetes/kube-apiserver --allow-privileged=false --option1=20,30,40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[1],
 			"2:45 ../kubernetes/kube-apiserver --allow-privileged=false",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[2],
 			"niinai   13617  2635 99 19:26 pts/20   00:03:08 ./kube-apiserver --insecure-port=0 --anonymous-auth",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[3],
 			"2:45 ../kubernetes/kube-apiserver --secure-port=0 --audit-log-maxage=40 --option",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[4],
 			"2:45 ../kubernetes/kube-apiserver --max-backlog=20 --secure-port=0 --audit-log-maxage=40 --option",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[5],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=WebHook,RBAC ---audit-log-maxage=40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[6],
 			"2:45 .. --kubelet-clientkey=foo --kubelet-client-certificate=bar --admission-control=Webhook,RBAC",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[7],
 			"2:45 ..  --secure-port=0 --kubelet-client-certificate=bar --admission-control=Webhook,RBAC",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[8],
 			"644",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[9],
 			"640",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[9],
 			"600",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[10],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=WebHook,RBAC ---audit-log-maxage=40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[11],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=WebHook,RBAC ---audit-log-maxage=40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[12],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=WebHook,Something,RBAC ---audit-log-maxage=40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[13],
 			"2:45 ../kubernetes/kube-apiserver --option --admission-control=Something ---audit-log-maxage=40",
+			"",
 		},
 		{
 			// check for ':' as argument-value separator, with space between arg and val
 			controls.Groups[0].Checks[14],
 			"2:45 kube-apiserver some-arg: some-val --admission-control=Something ---audit-log-maxage=40",
+			"",
 		},
 		{
 			// check for ':' as argument-value separator, with no space between arg and val
 			controls.Groups[0].Checks[14],
 			"2:45 kube-apiserver some-arg:some-val --admission-control=Something ---audit-log-maxage=40",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[15],
+			"",
 			"{\"readOnlyPort\": 15000}",
 		},
 		{
 			controls.Groups[0].Checks[16],
+			"",
 			"{\"stringValue\": \"WebHook,Something,RBAC\"}",
 		},
 		{
 			controls.Groups[0].Checks[17],
+			"",
 			"{\"trueValue\": true}",
 		},
 		{
 			controls.Groups[0].Checks[18],
+			"",
 			"{\"readOnlyPort\": 15000}",
 		},
 		{
 			controls.Groups[0].Checks[19],
+			"",
 			"{\"authentication\": { \"anonymous\": {\"enabled\": false}}}",
 		},
 		{
 			controls.Groups[0].Checks[20],
+			"",
 			"readOnlyPort: 15000",
 		},
 		{
 			controls.Groups[0].Checks[21],
+			"",
 			"readOnlyPort: 15000",
 		},
 		{
 			controls.Groups[0].Checks[22],
+			"",
 			"authentication:\n  anonymous:\n    enabled: false",
 		},
 		{
 			controls.Groups[0].Checks[26],
+			"",
 			"currentMasterVersion: 1.12.7",
 		},
 		{
 			controls.Groups[0].Checks[27],
 			"--peer-client-cert-auth",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[27],
 			"--abc=true --peer-client-cert-auth --efg=false",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[27],
 			"--abc --peer-client-cert-auth --efg",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[27],
 			"--peer-client-cert-auth=true",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[27],
 			"--abc --peer-client-cert-auth=true --efg",
+			"",
 		},
 		{
 			controls.Groups[0].Checks[28],
 			"--abc --peer-client-cert-auth=false --efg",
+			"",
 		},
 	}
 
 	for _, c := range cases {
-		res := c.Tests.execute(c.str, c.IsMultiple).testResult
-		if !res {
+		c.Check.AuditOutput = c.str
+		c.Check.AuditConfigOutput = c.strConfig
+		res, err := c.Check.execute()
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		if !res.testResult {
 			t.Errorf("%s, expected:%v, got:%v\n", c.Text, true, res)
 		}
 	}
@@ -219,8 +257,12 @@ func TestTestExecuteExceptions(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := c.Tests.execute(c.str, c.IsMultiple).testResult
-		if res {
+		c.Check.AuditConfigOutput = c.str
+		res, err := c.Check.execute()
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		if res.testResult {
 			t.Errorf("%s, expected:%v, got:%v\n", c.Text, false, res)
 		}
 	}

--- a/integration/testdata/cis-1.5/job-node.data
+++ b/integration/testdata/cis-1.5/job-node.data
@@ -14,7 +14,7 @@
 [PASS] 4.2.1 Ensure that the --anonymous-auth argument is set to false (Scored)
 [PASS] 4.2.2 Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)
 [PASS] 4.2.3 Ensure that the --client-ca-file argument is set as appropriate (Scored)
-[FAIL] 4.2.4 Ensure that the --read-only-port argument is set to 0 (Scored)
+[PASS] 4.2.4 Ensure that the --read-only-port argument is set to 0 (Scored)
 [PASS] 4.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)
 [FAIL] 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true (Scored)
 [PASS] 4.2.7 Ensure that the --make-iptables-util-chains argument is set to true (Scored)
@@ -32,15 +32,6 @@ chmod 644 /etc/kubernetes/proxy.conf
 
 4.1.4 Run the below command (based on the file location on your system) on the each worker node.
 For example, chown root:root /etc/kubernetes/proxy.conf
-
-4.2.4 If using a Kubelet config file, edit the file to set readOnlyPort to 0.
-If using command line arguments, edit the kubelet service file
-/etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and
-set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
---read-only-port=0
-Based on your system, restart the kubelet service. For example:
-systemctl daemon-reload
-systemctl restart kubelet.service
 
 4.2.6 If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
 If using command line arguments, edit the kubelet service file
@@ -80,7 +71,7 @@ systemctl restart kubelet.service
 
 
 == Summary ==
-16 checks PASS
-6 checks FAIL
+17 checks PASS
+5 checks FAIL
 1 checks WARN
 0 checks INFO

--- a/integration/testdata/cis-1.5/job.data
+++ b/integration/testdata/cis-1.5/job.data
@@ -227,7 +227,7 @@ minimum.
 [PASS] 4.2.1 Ensure that the --anonymous-auth argument is set to false (Scored)
 [PASS] 4.2.2 Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)
 [PASS] 4.2.3 Ensure that the --client-ca-file argument is set as appropriate (Scored)
-[FAIL] 4.2.4 Ensure that the --read-only-port argument is set to 0 (Scored)
+[PASS] 4.2.4 Ensure that the --read-only-port argument is set to 0 (Scored)
 [PASS] 4.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)
 [FAIL] 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true (Scored)
 [PASS] 4.2.7 Ensure that the --make-iptables-util-chains argument is set to true (Scored)
@@ -245,15 +245,6 @@ chmod 644 /etc/kubernetes/proxy.conf
 
 4.1.4 Run the below command (based on the file location on your system) on the each worker node.
 For example, chown root:root /etc/kubernetes/proxy.conf
-
-4.2.4 If using a Kubelet config file, edit the file to set readOnlyPort to 0.
-If using command line arguments, edit the kubelet service file
-/etc/systemd/system/kubelet.service.d/10-kubeadm.conf on each worker node and
-set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
---read-only-port=0
-Based on your system, restart the kubelet service. For example:
-systemctl daemon-reload
-systemctl restart kubelet.service
 
 4.2.6 If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
 If using command line arguments, edit the kubelet service file
@@ -293,8 +284,8 @@ systemctl restart kubelet.service
 
 
 == Summary ==
-16 checks PASS
-6 checks FAIL
+17 checks PASS
+5 checks FAIL
 1 checks WARN
 0 checks INFO
 [INFO] 5 Kubernetes Policies


### PR DESCRIPTION
Fixes #646

This is a bit of a saga:

* Settings made on the command line override settings in a Kubernetes config file
* Audit commands are run to detect command line and other "external" settings; AuditConfig commands are used to get a configuration file in JSON or YAML format
* In the case of 4.2.4 the read-only-port setting defaults to 0 if it's set in the config file, so the test should pass if any of the following are true: --read-only-port is set to 0 on the command line; --read-only-port is not set on the command line and readOnlyPort is set to 0 in the config file; readOnlyPort is not set on either the command line or the config file.

To make this work I have refactored the way that a set of tests in a Check are run. Previously they ran all testItems in the check as Audit commands, and if that didn't work they ran all testItems as AuditConfig commands. I have reworked this so that for each test it will attempt to find the flag on the command line first and if that's not found, look for the config setting, and then perform the binary op across all the test items. 

While here, I've tidied up `runAudit()` and I think the reasoning for different PASS / WARN / FAIL states is easier to read now. 



