### PR TITLE
Updating section id 4.6

### DIFF
--- a/cfg/rh-0.7/master.yaml
+++ b/cfg/rh-0.7/master.yaml
@@ -895,7 +895,7 @@ groups:
 
       - id: 4.6
         text: "Verify the scheduler pod specification file ownership set by OpenShift"
-        audit: "stat -c %u:%g /etc/origin/node/pods/controller.yaml"
+        audit: "stat -c %U:%G /etc/origin/node/pods/controller.yaml"
         tests:
           test_items:
             - flag: "root:root"


### PR DESCRIPTION
      - id: 4.6
        text: "Verify the scheduler pod specification file ownership set by OpenShift"
        audit: "stat -c %u:%g /etc/origin/node/pods/controller.yaml" -- (lower case u and g ) it returns the uID and gID in numeric i.e 0:0 not root:root.
it supposed to be Uppercase: audit: "stat -c %U:%G /etc/origin/node/pods/controller.yaml"