### PR TITLE
Multi-arch build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,18 @@ before_install:
 
 script:
   - yamllint -c ./.yamllint.yaml .
-  - GO111MODULE=on go test ./...
+
+  # Run unit and integration tests
+  - make tests
+  - make integration-tests
+
+  # Build a local container image to test that the install sub-command works
   - IMAGE_NAME=kube-bench make build-docker
   - docker run -v `pwd`:/host kube-bench install
   - test -d cfg
   - test -f kube-bench
-  - make tests
-  - make integration-tests
+  # Build and push the multi-arch Docker image
+  - make docker
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - pip install --user yamllint==1.18.0
   - gem install --no-document fpm
   - go get -t -v ./...
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 script:
   - yamllint -c ./.yamllint.yaml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ COPY main.go .
 COPY check/ check/
 COPY cmd/ cmd/
 ARG KUBEBENCH_VERSION
-RUN GO111MODULE=on CGO_ENABLED=0 go install -a -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w"
+ARG GOOS=linux
+ARG GOARCH=amd64
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -a -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
 
 FROM alpine:3.12 AS run
 WORKDIR /opt/kube-bench/


### PR DESCRIPTION
Addresses #671 by building a multi-arch image for arm64 as well as amd64

Also tidied up the makefile a bit, including: 
 - removed duplicate run of unit tests
 - added some dependencies for kind-run tests to make sure it's using an up-to-date image

Note that in the Dockerfile for some reason `go install` created an executable with a different name (not `kube-bench`) on amd64. I've worked around this by using `go build` instead. 
