### PR TITLE
Default log output to stderr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for taking an interest in contributing to kube-bench !
 - For questions and bug reports, please include the following information:
   - version of kube-bench you are running (from kube-bench version) along with the command line options you are using.
   - version of Kubernetes you are running (from kubectl version or oc version for Openshift).
-  - Verbose log output, by setting the `-v 10` and `--logtostderr` command line options.
+  - Verbose log output, by setting the `-v 10` command line option.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -306,9 +306,9 @@ You can read more about `kube-bench` configuration in our [documentation](docs/R
 
 ## Troubleshooting
 
-Running `kube-bench` with the `-v 3 --logtostderr` parameters will generate debug logs that can be very helpful for debugging problems.
+Running `kube-bench` with the `-v 3` parameter will generate debug logs that can be very helpful for debugging problems.
 
-If you are using one of the example `job*.yaml` files, you will need to edit the `command` field, for example `["kube-bench", "-v", "3", "--logtostderr"]`. Once the job has run, the logs can be retrieved using `kubectl logs` on the job's pod.
+If you are using one of the example `job*.yaml` files, you will need to edit the `command` field, for example `["kube-bench", "-v", "3"]`. Once the job has run, the logs can be retrieved using `kubectl logs` on the job's pod.
 
 ## Test config YAML representation
 
@@ -358,7 +358,7 @@ If you think you have found a bug please follow the instructions below.
 - Open a [new issue](https://github.com/aquasecurity/kube-bench/issues/new) if a duplicate doesn't already exist.
 - Note the version of kube-bench you are running (from `kube-bench version`) and the command line options you are using.
 - Note the version of Kubernetes you are running (from `kubectl version` or `oc version` for OpenShift).
-- Set `-v 10 --logtostderr` command line options and save the log output. Please paste this into your issue.
+- Set `-v 10` command line option and save the log output. Please paste this into your issue.
 - Remember users might be searching for your issue in the future, so please give it a meaningful title to help others.
 
 ### Features

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -175,6 +175,10 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&kubeVersion, "version", "", "Manually specify Kubernetes version, automatically detected if unset")
 	RootCmd.PersistentFlags().StringVar(&benchmarkVersion, "benchmark", "", "Manually specify CIS benchmark version. It would be an error to specify both --version and --benchmark flags")
 
+	if err := goflag.Set("logtostderr", "true"); err != nil {
+		fmt.Printf("unable to set logtostderr: %+v\n", err)
+		os.Exit(-1)
+	}
 	goflag.CommandLine.VisitAll(func(goflag *goflag.Flag) {
 		RootCmd.PersistentFlags().AddGoFlag(goflag)
 	})


### PR DESCRIPTION
Closes #695 

before:

```
$ ./kube-bench 

failed to get a set of executables needed for tests: unable to detect running programs for component "kubelet"

$ ./kube-bench --logtostderr
W0907 22:30:01.566933   17118 util.go:96] 
Unable to detect running programs for component "apiserver"
The following "master node" programs have been searched, but none of them have been found:
        - kube-apiserver
        - hyperkube apiserver
        - hyperkube kube-apiserver
        - apiserver
...
```

after:

```
$ ./kube-bench 
W0907 22:28:23.580054   16389 util.go:96] 
Unable to detect running programs for component "apiserver"
The following "master node" programs have been searched, but none of them have been found:
        - kube-apiserver
        - hyperkube apiserver
        - hyperkube kube-apiserver
        - apiserver
...

$ ./kube-bench --logtostderr=false

failed to get a set of executables needed for tests: unable to detect running programs for component "kubelet"
```