### PR TITLE
Note about OpenShift OCP 4.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Table of Contents
     - [Running in a Kubernetes cluster](#running-in-a-kubernetes-cluster)
     - [Running in an AKS cluster](#running-in-an-aks-cluster)
     - [Running in an EKS cluster](#running-in-an-eks-cluster)
+    - [Running on OpenShift](#running-on-openshift)
+    - [Running in an GKE cluster](#running-in-a-gke-cluster)
     - [Installing from a container](#installing-from-a-container)
     - [Installing from sources](#installing-from-sources)
-  - [Running on OpenShift](#running-on-openshift)
-    - [Running in an GKE cluster](#running-in-an-gke-cluster)
   - [Output](#output)
   - [Configuration](#configuration)
   - [Troubleshooting](#troubleshooting)
@@ -232,6 +232,34 @@ docker push <AWS_ACCT_NUMBER>.dkr.ecr.<AWS_REGION>.amazonaws.com/k8s/kube-bench:
 8. Retrieve the value of this Pod and output the report, note the Pod name will vary: `kubectl logs kube-bench-<value>`
   - You can save the report for later reference: `kubectl logs kube-bench-<value> > kube-bench-report.txt`
 
+### Running on OpenShift
+
+| OpenShift Hardening Guide | kube-bench config |
+|---|---|
+| ocp-3.10| rh-0.7 |
+| ocp-3.11| rh-0.7 |
+| ocp-4.* | Not supported |
+
+kube-bench includes a set of test files for Red Hat's OpenShift hardening guide for OCP 3.10 and 3.11. To run this you will need to specify `--benchmark rh-07`, or `--version ocp-3.10` or `--version ocp-3.11`
+
+when you run the `kube-bench` command (either directly or through YAML).
+
+There is work in progress on a [CIS Red Hat OpenShift Container Platform Benchmark](https://workbench.cisecurity.org/benchmarks/5248) which we believe should cover OCP 4.* and we intend to add support in kube-bench when it's published. 
+
+### Running in a GKE cluster
+
+| CIS Benchmark | Targets |
+|---|---|
+| gke-1.0| master, controlplane, node, etcd, policies, managedservices |
+
+kube-bench includes benchmarks for GKE. To run this you will need to specify `--benchmark gke-1.0` when you run the `kube-bench` command.
+
+To run the benchmark as a job in your GKE cluster apply the included `job-gke.yaml`.
+
+```
+kubectl apply -f job-gke.yaml
+```
+
 ### Installing from a container
 
 This command copies the kube-bench binary and configuration files to your host from the Docker container:
@@ -256,30 +284,6 @@ go build -o kube-bench .
 
 # Run all checks
 ./kube-bench
-```
-
-### Running on OpenShift
-
-| OpenShift Hardening Guide | kube-bench config |
-|---|---|
-| ocp-3.10| rh-0.7 |
-| ocp-3.11| rh-0.7 |
-
-kube-bench includes a set of test files for Red Hat's OpenShift hardening guide for OCP 3.10 and 3.11. To run this you will need to specify `--benchmark rh-07`, or `--version ocp-3.10` or `--version ocp-3.11`
-
-when you run the `kube-bench` command (either directly or through YAML).
-
-### Running in an GKE cluster
-| CIS Benchmark | Targets |
-|---|---|
-| gke-1.0| master, controlplane, node, etcd, policies, managedservices |
-
-kube-bench includes benchmarks for GKE. To run this you will need to specify `--benchmark gke-1.0` when you run the `kube-bench` command.
-
-To run the benchmark as a job in your GKE cluster apply the included `job-gke.yaml`.
-
-```
-kubectl apply -f job-gke.yaml
 ```
 
 ## Output


### PR DESCRIPTION
- Add note about why we don't support OCP 4.*
- Move GKE & OpenShift sub-sections next to EKS and AKS
- Minor corrections