### PR TITLE
Set actualResult

### DIFF
--- a/check/test.go
+++ b/check/test.go
@@ -169,6 +169,7 @@ func (t testItem) execute(s string) *testOutput {
 		}
 	}
 
+	result.actualResult = s
 	return result
 }
 


### PR DESCRIPTION
actual Result is used later on to get actual value and the --include-test-output values but it never got set so its always empty.