### PR TITLE
Fix go vet issues

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -67,8 +67,8 @@ type Check struct {
 	Audit             string   `json:"audit"`
 	AuditConfig       string   `yaml:"audit_config"`
 	Type              string   `json:"type"`
-	Tests             *tests   `json:"omit"`
-	Set               bool     `json:"omit"`
+	Tests             *tests   `json:"-"`
+	Set               bool     `json:"-"`
 	Remediation       string   `json:"remediation"`
 	TestInfo          []string `json:"test_info"`
 	State             `json:"status"`
@@ -77,8 +77,8 @@ type Check struct {
 	IsMultiple        bool   `yaml:"use_multiple_values"`
 	ExpectedResult    string `json:"expected_result"`
 	Reason            string `json:"reason,omitempty"`
-	AuditOutput       string `json:"omit"`
-	AuditConfigOutput string `json:"omit"`
+	AuditOutput       string `json:"-"`
+	AuditConfigOutput string `json:"-"`
 }
 
 // Runner wraps the basic Run method.
@@ -101,7 +101,6 @@ func (r *defaultRunner) Run(c *Check) State {
 // Run executes the audit commands specified in a check and outputs
 // the results.
 func (c *Check) run() State {
-
 	// Since this is an Scored check
 	// without tests return a 'WARN' to alert
 	// the user that this check needs attention

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -120,9 +120,9 @@ func findPodForJob(clientset *kubernetes.Clientset, jobName string, duration tim
 				}
 			}
 		}
-	}
 
-	return nil, fmt.Errorf("no Pod found for Job %q", jobName)
+		return nil, fmt.Errorf("no Pod found for Job %q", jobName)
+	}
 }
 
 func getPodLogs(clientset *kubernetes.Clientset, pod *apiv1.Pod) string {

--- a/makefile
+++ b/makefile
@@ -57,7 +57,7 @@ build-docker:
 
 # unit tests
 tests:
-	GO111MODULE=on go test -short -race -timeout 30s -coverprofile=coverage.txt -covermode=atomic ./...
+	GO111MODULE=on go test -vet all -short -race -timeout 30s -coverprofile=coverage.txt -covermode=atomic ./...
 
 # integration tests using kind
 integration-tests: build-docker


### PR DESCRIPTION
* to omit the property from JSON parsing one should use "-". "omit" in
that case would use omit tag
* The error was not reachable in the tests, so I moved it to the place
where it make sense for me (but maybe it was just unnecessary)

Additionaly, I have enabled running all `go vet` linters in Travis CI.