### PR TITLE
Allow for skip to be defined on a group-level skipping all checks inside

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -39,6 +39,9 @@ const (
 	// INFO informational message
 	INFO State = "INFO"
 
+	// SKIP for when a check should be skipped.
+	SKIP = "skip"
+
 	// MASTER a master node
 	MASTER NodeType = "master"
 	// NODE a node
@@ -111,7 +114,7 @@ func (c *Check) run() State {
 	}
 
 	// If check type is skip, force result to INFO
-	if c.Type == "skip" {
+	if c.Type == SKIP {
 		c.Reason = "Test marked as skip"
 		c.State = INFO
 		return c.State

--- a/check/controls.go
+++ b/check/controls.go
@@ -87,13 +87,12 @@ func (controls *Controls) RunChecks(runner Runner, filter Predicate) Summary {
 				continue
 			}
 
-			state := runner.Run(check)
-
-			// Set check state to INFO if group has skip set
+			// propagate skip type to check if set at the group level.
 			if group.Skip {
-				state = INFO
-				check.State = INFO
+				check.Type = SKIP
 			}
+
+			state := runner.Run(check)
 
 			check.TestInfo = append(check.TestInfo, check.Remediation)
 

--- a/check/controls.go
+++ b/check/controls.go
@@ -38,6 +38,7 @@ type Controls struct {
 // Group is a collection of similar checks.
 type Group struct {
 	ID     string   `yaml:"id" json:"section"`
+	Skip   bool     `yaml:"skip" json:"skip"`
 	Pass   int      `json:"pass"`
 	Fail   int      `json:"fail"`
 	Warn   int      `json:"warn"`
@@ -87,6 +88,13 @@ func (controls *Controls) RunChecks(runner Runner, filter Predicate) Summary {
 			}
 
 			state := runner.Run(check)
+
+			// Set check state to INFO if group has skip set
+			if group.Skip {
+				state = INFO
+				check.State = INFO
+			}
+
 			check.TestInfo = append(check.TestInfo, check.Remediation)
 
 			// Check if we have already added this checks group.
@@ -95,6 +103,7 @@ func (controls *Controls) RunChecks(runner Runner, filter Predicate) Summary {
 				w := &Group{
 					ID:     group.ID,
 					Text:   group.Text,
+					Skip:   group.Skip,
 					Checks: []*Check{},
 				}
 

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -99,7 +99,7 @@ groups:
 func TestControls_RunChecks_Skipped(t *testing.T) {
 	t.Run("Should run checks matching the filter and update summaries", func(t *testing.T) {
 		// given
-		runner := new(mockRunner)
+		normalRunner := &defaultRunner{}
 		// and
 		in := []byte(`
 ---
@@ -109,38 +109,19 @@ groups:
   skip: true
   checks:
   - id: G1/C1
-- id: G2
-  checks:
-  - id: G2/C1
-    text: "Verify that the SomeSampleFlag argument is set to true"
-    audit: "grep -B1 SomeSampleFlag=true /this/is/a/file/path"
-    tests:
-      test_items:
-      - flag: "SomeSampleFlag=true"
-        compare:
-          op: has
-          value: "true"
-        set: true
-    remediation: |
-      Edit the config file /this/is/a/file/path and set SomeSampleFlag to true.
-    scored: true
 `)
 		controls, err := NewControls(MASTER, in)
 		assert.NoError(t, err)
 
-		runner.On("Run", controls.Groups[0].Checks[0]).Return(PASS)
-		runner.On("Run", controls.Groups[1].Checks[0]).Return(FAIL)
-
-		var runAll Predicate = func(group *Group, c *Check) bool {
+		var allChecks Predicate = func(group *Group, c *Check) bool {
 			return true
 		}
-		controls.RunChecks(runner, runAll)
+		controls.RunChecks(normalRunner, allChecks)
 
 		G1 := controls.Groups[0]
 		assertEqualGroupSummary(t, 0, 0, 1, 0, G1)
-		G2 := controls.Groups[1]
-		assertEqualGroupSummary(t, 0, 1, 0, 0, G2)
 	})
+
 }
 
 func TestControls_RunChecks(t *testing.T) {


### PR DESCRIPTION
This fixes issue #649 allowing groups to be defined to be skipped. this is done by setting 'Skip' on the group to true. When checks are run this will then set the state of any checks within that group to info (the check is still technically run but just overridden to be INFO as I wasn't sure on what the desired behaviour here was, we could just skip the check entirely and not run and just set it to INFO).

Please let me know if there are any additional changes you want done to this!