### PR TITLE
Fix tls-cipher-suites check for kube-apiserver

### DIFF
--- a/cfg/cis-1.5/master.yaml
+++ b/cfg/cis-1.5/master.yaml
@@ -908,7 +908,7 @@ groups:
           test_items:
             - flag: "--tls-cipher-suites"
               compare:
-                op: has
+                op: valid_elements
                 value: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
               set: true
         remediation: |

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -832,7 +832,7 @@ groups:
           test_items:
             - flag: "--tls-cipher-suites"
               compare:
-                op: has
+                op: valid_elements
                 value: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
         remediation: |
           Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml


### PR DESCRIPTION
**Why do we need it?**
According to CIS Benchmark, item 1.2.35 allows kube-apiserver to configure with a subset of the given cipher suites. 
```
Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
on the master node and set the below parameter as follows, or to a subset of these values.
```
However, using the current configuration, it checks whether this whole set is the same set or is a subset of the cipher suites configured in the kube-apiserver which violates the description. This PR changes `has` op to `valid_elements` to correct the check logic.