### PR TITLE
Automate check 3.2.1 Ensure that a minimal audit policy is created

### DIFF
--- a/cfg/cis-1.5/controlplane.yaml
+++ b/cfg/cis-1.5/controlplane.yaml
@@ -21,7 +21,11 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Scored)"
-        type: "manual"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
         remediation: |
           Create an audit policy file for your cluster.
         scored: true

--- a/cfg/cis-1.6/controlplane.yaml
+++ b/cfg/cis-1.6/controlplane.yaml
@@ -21,7 +21,11 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        type: "manual"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
         remediation: |
           Create an audit policy file for your cluster.
         scored: false

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -180,7 +180,15 @@ etcd:
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
 controlplane:
-  components: []
+  components:
+    - apiserver
+
+  apiserver:
+    bins:
+      - "kube-apiserver"
+      - "hyperkube apiserver"
+      - "hyperkube kube-apiserver"
+      - "apiserver"
 
 policies:
   components: []

--- a/integration/testdata/cis-1.5/job.data
+++ b/integration/testdata/cis-1.5/job.data
@@ -193,7 +193,7 @@ on the master node and set the below parameter.
 [INFO] 3.1 Authentication and Authorization
 [WARN] 3.1.1 Client certificate authentication should not be used for users (Not Scored)
 [INFO] 3.2 Logging
-[WARN] 3.2.1 Ensure that a minimal audit policy is created (Scored)
+[FAIL] 3.2.1 Ensure that a minimal audit policy is created (Scored)
 [WARN] 3.2.2 Ensure that the audit policy covers key security concerns (Not Scored)
 
 == Remediations ==
@@ -208,8 +208,8 @@ minimum.
 
 == Summary ==
 0 checks PASS
-0 checks FAIL
-3 checks WARN
+1 checks FAIL
+2 checks WARN
 0 checks INFO
 [INFO] 4 Worker Node Security Configuration
 [INFO] 4.1 Worker Node Configuration Files


### PR DESCRIPTION
**Why do we need it?**
This PR automates the verification of `3.2.1. Ensuring a minimal audit policy is created` by validating `--audit-policy-file` is set to kube-apiserver start command.

If this option is configured, the kube-apiserver will check the validity of the policy file during startup.
Quote from [Auditing](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy):
> Note that the rules field must be provided in the audit policy file. A policy with no (0) rules is treated as illegal.

So it's safe to mark the item as PASS as long as it is set.