### PR TITLE
Fix defaultkubeconfig in config.yaml to resolve variable exposure in remediation

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -48,8 +48,7 @@ master:
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
     kubeconfig:
       - /etc/kubernetes/scheduler.conf
-    defaultkubeconfig:
-      - /etc/kubernetes/scheduler.conf
+    defaultkubeconfig: /etc/kubernetes/scheduler.conf
 
   controllermanager:
     bins:
@@ -67,8 +66,7 @@ master:
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
     kubeconfig:
       - /etc/kubernetes/controller-manager.conf
-    defaultkubeconfig:
-      - /etc/kubernetes/controller-manager.conf
+    defaultkubeconfig: /etc/kubernetes/controller-manager.conf
 
   etcd:
     optional: true


### PR DESCRIPTION
**Why do we need it?**
This PR aims at fixing the bug reported in https://github.com/aquasecurity/kube-bench/pull/756.

**How to reproduce this bug?**
The `defaultkubeconfig` for scheduler and controllermanager don't take effect as they are mistakenly configured as an array.

When no files can be found in the declared `kubeconfig` location options. The substitution should fall back to replacing the variables with the default values, however, as the object type is mismatched, so there's no replacement to take place.
```
scheduler:
    kubeconfig:
      - /etc/kubernetes/scheduler.conf
    defaultkubeconfig: /etc/kubernetes/scheduler.conf
```
The issue is initially introduced in https://github.com/aquasecurity/kube-bench/pull/738.
