### PR TITLE
Automate 1.2.1

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -299,7 +299,6 @@ groups:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
         tests:
           test_items:
             - flag: "--anonymous-auth"


### PR DESCRIPTION
Currently, 1.2.1 has automated checks but in results it always warns. So without a manual type, it will fail or pass automatically.