### PR TITLE
Fix 1.1.7 1.1.8 for KOPS

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -91,7 +91,8 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
         tests:
           test_items:
             - flag: "permissions"
@@ -106,7 +107,8 @@ groups:
 
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
         tests:
           test_items:
             - flag: "root:root"

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -81,6 +81,7 @@ master:
       - /var/snap/etcd/common/etcd.conf.yaml
       - /var/snap/microk8s/current/args/etcd
       - /usr/lib/systemd/system/etcd.service
+      - /etc/kubernetes/manifests
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
 
   flanneld:


### PR DESCRIPTION
In KOPS used etc-manager which bootstrap 2 etcd clusters: main (`/etc/kubernetes/manifests/etcd-main.manifest`) and event (`/etc/kubernetes/manifests/etcd-events.manifest`). So i changed logic and it check all manifests which contain etcd in naming in `/etc/kubernetes/manifests`.
Signed-off-by: Dmytro Oboznyi <dmytro.oboznyi@syncier.com>