### PR TITLE
Fix file permissions false positive

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -221,7 +221,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod 644 $KUBECONFIG
+          chmod 644 $schedulerkubeconfig
         scored: true
 
       - id: 1.1.16
@@ -236,7 +236,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown root:root $KUBECONFIG
+          chown root:root $schedulerkubeconfig
         scored: true
 
       - id: 1.1.17
@@ -254,7 +254,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod 644 $KUBECONFIG
+          chmod 644 $controllermanagerkubeconfig
         scored: true
 
       - id: 1.1.18
@@ -269,7 +269,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown root:root $KUBECONFIG
+          chown root:root $controllermanagerkubeconfig
         scored: true
 
       - id: 1.1.19

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -209,10 +209,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: |
-           KUBECONFIG=$(ps -ef | grep kube-scheduler | grep -- --config= | awk -F '--config=' '{print $2}' | awk '{print $1}')
-           if test -z $KUBECONFIG; then KUBECONFIG=$schedulerkubeconfig; fi
-           if test -e $KUBECONFIG; then stat -c permissions=%a $KUBECONFIG; fi
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -227,10 +224,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: |
-           KUBECONFIG=$(ps -ef | grep kube-scheduler | grep -- --config= | awk -F '--config=' '{print $2}' | awk '{print $1}')
-           if test -z $KUBECONFIG; then KUBECONFIG=$schedulerkubeconfig; fi
-           if test -e $KUBECONFIG; then stat -c %U:%G $KUBECONFIG; fi
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -242,10 +236,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: |
-           KUBECONFIG=$(ps -ef | grep kube-controller-manager | grep -- --kubeconfig= | awk -F '--kubeconfig=' '{print $2}' | awk '{print $1}')
-           if test -z $KUBECONFIG; then KUBECONFIG=$controllermanagerkubeconfig; fi
-           if test -e $KUBECONFIG; then stat -c permissions=%a $KUBECONFIG; fi
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -260,10 +251,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: |
-           KUBECONFIG=$(ps -ef | grep kube-controller-manager | grep -- --kubeconfig= | awk -F '--kubeconfig=' '{print $2}' | awk '{print $1}')
-           if test -z $KUBECONFIG; then KUBECONFIG=$controllermanagerkubeconfig; fi
-           if test -e $KUBECONFIG; then stat -c %U:%G $KUBECONFIG; fi
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -196,7 +196,10 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: |
+           KUBECONFIG=$(ps -ef | grep kube-scheduler | grep -- --config= | awk -F '--config=' '{print $2}' | awk '{print $1}')
+           if test -z $KUBECONFIG; then KUBECONFIG=$schedulerkubeconfig; fi
+           if test -e $KUBECONFIG; then stat -c permissions=%a $KUBECONFIG; fi
         tests:
           test_items:
             - flag: "permissions"
@@ -206,24 +209,30 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod 644 $schedulerkubeconfig
+          chmod 644 $KUBECONFIG
         scored: true
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: |
+           KUBECONFIG=$(ps -ef | grep kube-scheduler | grep -- --config= | awk -F '--config=' '{print $2}' | awk '{print $1}')
+           if test -z $KUBECONFIG; then KUBECONFIG=$schedulerkubeconfig; fi
+           if test -e $KUBECONFIG; then stat -c %U:%G $KUBECONFIG; fi
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown root:root $schedulerkubeconfig
+          chown root:root $KUBECONFIG
         scored: true
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: |
+           KUBECONFIG=$(ps -ef | grep kube-controller-manager | grep -- --kubeconfig= | awk -F '--kubeconfig=' '{print $2}' | awk '{print $1}')
+           if test -z $KUBECONFIG; then KUBECONFIG=$controllermanagerkubeconfig; fi
+           if test -e $KUBECONFIG; then stat -c permissions=%a $KUBECONFIG; fi
         tests:
           test_items:
             - flag: "permissions"
@@ -233,19 +242,22 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod 644 $controllermanagerkubeconfig
+          chmod 644 $KUBECONFIG
         scored: true
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        audit: |
+           KUBECONFIG=$(ps -ef | grep kube-controller-manager | grep -- --kubeconfig= | awk -F '--kubeconfig=' '{print $2}' | awk '{print $1}')
+           if test -z $KUBECONFIG; then KUBECONFIG=$controllermanagerkubeconfig; fi
+           if test -e $KUBECONFIG; then stat -c %U:%G $KUBECONFIG; fi
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chown root:root $controllermanagerkubeconfig
+          chown root:root $KUBECONFIG
         scored: true
 
       - id: 1.1.19

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -118,7 +118,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Automated)"
-        audit: | 
+        audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
           ps -ef | grep $kubeletbin | grep -- --cni-bin-dir | sed 's%.*cni-bin-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
         use_multiple_values: true

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -117,7 +117,7 @@ groups:
         scored: true
 
       - id: 1.1.9
-        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Automated)"
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
           find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a
@@ -134,7 +134,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
           find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c %U:%G
@@ -286,7 +286,7 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
         audit: "find /etc/kubernetes/pki -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
@@ -302,7 +302,7 @@ groups:
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /etc/kubernetes/pki -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
@@ -321,7 +321,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -457,7 +457,7 @@ groups:
         scored: true
 
       - id: 1.2.10
-        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -492,7 +492,7 @@ groups:
         scored: true
 
       - id: 1.2.12
-        text: "Ensure that the admission control plugin AlwaysPullImages is set (Automated)"
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -508,7 +508,7 @@ groups:
         scored: false
 
       - id: 1.2.13
-        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -828,7 +828,7 @@ groups:
         scored: true
 
       - id: 1.2.33
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -849,7 +849,7 @@ groups:
         scored: false
 
       - id: 1.2.35
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -870,7 +870,7 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -117,9 +117,16 @@ groups:
         scored: true
 
       - id: 1.1.9
-        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c permissions=%a <path/to/cni/files>"
-        type: "manual"
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Automated)"
+        audit: | 
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
+          ps -ef | grep $kubeletbin | grep -- --cni-bin-dir | sed 's%.*cni-bin-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
+        use_multiple_values: true
+        test_items:
+          - flag: "permissions"
+            compare:
+              op: bitmask
+              value: "644"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -127,9 +134,14 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G <path/to/cni/files>"
-        type: "manual"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
+          ps -ef | grep $kubeletbin | grep -- --cni-bin-dir | sed 's%.*cni-bin-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -274,7 +286,7 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
         audit: "find /etc/kubernetes/pki -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
@@ -290,7 +302,7 @@ groups:
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
         audit: "find /etc/kubernetes/pki -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
@@ -309,7 +321,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -445,7 +457,7 @@ groups:
         scored: true
 
       - id: 1.2.10
-        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -480,7 +492,7 @@ groups:
         scored: true
 
       - id: 1.2.12
-        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -496,7 +508,7 @@ groups:
         scored: false
 
       - id: 1.2.13
-        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -816,7 +828,7 @@ groups:
         scored: true
 
       - id: 1.2.33
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -837,7 +849,7 @@ groups:
         scored: false
 
       - id: 1.2.35
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -858,7 +870,7 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -122,7 +122,12 @@ groups:
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
           find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
-        test_items:
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
           - flag: "permissions"
             compare:
               op: bitmask

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -120,7 +120,7 @@ groups:
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Automated)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
-          ps -ef | grep $kubeletbin | grep -- --cni-bin-dir | sed 's%.*cni-bin-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
+          find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         test_items:
           - flag: "permissions"
@@ -137,7 +137,7 @@ groups:
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
-          ps -ef | grep $kubeletbin | grep -- --cni-bin-dir | sed 's%.*cni-bin-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
+          find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -128,10 +128,6 @@ groups:
               compare:
                 op: bitmask
                 value: "644"
-          - flag: "permissions"
-            compare:
-              op: bitmask
-              value: "644"
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,

--- a/cfg/cis-1.6/node.yaml
+++ b/cfg/cis-1.6/node.yaml
@@ -10,10 +10,7 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
-        audit: |
-           SERVICEFILE=$(find /lib/systemd/system/ | grep kubelet)
-           if test -z $SERVICEFILE; then SERVICEFILE=$kubeletsvc; fi
-           if test -e $SERVICEFILE; then stat -c permissions=%a $SERVICEFILE; fi
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -28,10 +25,7 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: |
-           SERVICEFILE=$(find /lib/systemd/system/ | grep kubelet)
-           if test -z $SERVICEFILE; then SERVICEFILE=$kubeletsvc; fi
-           if test -e $SERVICEFILE; then stat -c %U:%G $SERVICEFILE; fi
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
         tests:
           test_items:
             - flag: root:root

--- a/cfg/cis-1.6/node.yaml
+++ b/cfg/cis-1.6/node.yaml
@@ -23,7 +23,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chmod 644 $SERVICEFILE
+          chmod 644 $kubeletsvc
         scored: true
 
       - id: 4.1.2
@@ -38,7 +38,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chown root:root $SERVICEFILE
+          chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.6/node.yaml
+++ b/cfg/cis-1.6/node.yaml
@@ -10,7 +10,10 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        audit: |
+           SERVICEFILE=$(find /lib/systemd/system/ | grep kubelet)
+           if test -z $SERVICEFILE; then SERVICEFILE=$kubeletsvc; fi
+           if test -e $SERVICEFILE; then stat -c permissions=%a $SERVICEFILE; fi
         tests:
           test_items:
             - flag: "permissions"
@@ -20,19 +23,22 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chmod 644 $kubeletsvc
+          chmod 644 $SERVICEFILE
         scored: true
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: |
+           SERVICEFILE=$(find /lib/systemd/system/ | grep kubelet)
+           if test -z $SERVICEFILE; then SERVICEFILE=$kubeletsvc; fi
+           if test -e $SERVICEFILE; then stat -c %U:%G $SERVICEFILE; fi
         tests:
           test_items:
             - flag: root:root
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chown root:root $kubeletsvc
+          chown root:root $SERVICEFILE
         scored: true
 
       - id: 4.1.3

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -48,6 +48,7 @@ master:
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
     kubeconfig:
       - /etc/kubernetes/scheduler.conf
+      - /var/lib/kube-scheduler/config.yaml
     defaultkubeconfig: /etc/kubernetes/scheduler.conf
 
   controllermanager:
@@ -66,6 +67,7 @@ master:
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
     kubeconfig:
       - /etc/kubernetes/controller-manager.conf
+      - /var/lib/kube-controller-manager/kubeconfig
     defaultkubeconfig: /etc/kubernetes/controller-manager.conf
 
   etcd:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -15,6 +15,7 @@ master:
     - flanneld
     # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
     - kubernetes
+    - kubelet
 
   kubernetes:
     defaultconf: /etc/kubernetes/config
@@ -90,6 +91,12 @@ master:
     bins:
       - flanneld
     defaultconf: /etc/sysconfig/flanneld
+
+  kubelet:
+    optional: true
+    bins:
+      - "hyperkube kubelet"
+      - "kubelet"
 
 node:
   components:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -50,6 +50,7 @@ master:
     kubeconfig:
       - /etc/kubernetes/scheduler.conf
       - /var/lib/kube-scheduler/kubeconfig
+      - /var/lib/kube-scheduler/config.yaml
     defaultkubeconfig: /etc/kubernetes/scheduler.conf
 
   controllermanager:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -48,7 +48,7 @@ master:
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
     kubeconfig:
       - /etc/kubernetes/scheduler.conf
-      - /var/lib/kube-scheduler/config.yaml
+      - /var/lib/kube-scheduler/kubeconfig
     defaultkubeconfig: /etc/kubernetes/scheduler.conf
 
   controllermanager:

--- a/job-master.yaml
+++ b/job-master.yaml
@@ -21,6 +21,12 @@ spec:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd
               readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
               readOnly: true
@@ -34,6 +40,12 @@ spec:
         - name: var-lib-etcd
           hostPath:
             path: "/var/lib/etcd"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
         - name: etc-kubernetes
           hostPath:
             path: "/etc/kubernetes"

--- a/job-master.yaml
+++ b/job-master.yaml
@@ -35,6 +35,12 @@ spec:
             - name: usr-bin
               mountPath: /usr/local/mount-from-host/bin
               readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-etcd
@@ -52,3 +58,9 @@ spec:
         - name: usr-bin
           hostPath:
             path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"

--- a/job-master.yaml
+++ b/job-master.yaml
@@ -21,11 +21,23 @@ spec:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd
               readOnly: true
+            - name: var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              readOnly: true
             - name: var-lib-kube-scheduler
               mountPath: /var/lib/kube-scheduler
               readOnly: true
             - name: var-lib-kube-controller-manager
               mountPath: /var/lib/kube-controller-manager
+              readOnly: true
+            - name: etc-systemd
+              mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: srv-kubernetes
+              mountPath: /srv/kubernetes/
               readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
@@ -46,12 +58,24 @@ spec:
         - name: var-lib-etcd
           hostPath:
             path: "/var/lib/etcd"
+        - name: var-lib-kubelet
+          hostPath:
+            path: "/var/lib/kubelet"
         - name: var-lib-kube-scheduler
           hostPath:
             path: "/var/lib/kube-scheduler"
         - name: var-lib-kube-controller-manager
           hostPath:
             path: "/var/lib/kube-controller-manager"
+        - name: etc-systemd
+          hostPath:
+            path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: srv-kubernetes
+          hostPath:
+            path: "/srv/kubernetes"
         - name: etc-kubernetes
           hostPath:
             path: "/etc/kubernetes"

--- a/job-node.yaml
+++ b/job-node.yaml
@@ -18,6 +18,12 @@ spec:
             - name: etc-systemd
               mountPath: /etc/systemd
               readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: srv-kubernetes
+              mountPath: /srv/kubernetes/
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
               readOnly: true
@@ -34,6 +40,12 @@ spec:
         - name: etc-systemd
           hostPath:
             path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: srv-kubernetes
+          hostPath:
+            path: "/srv/kubernetes"
         - name: etc-kubernetes
           hostPath:
             path: "/etc/kubernetes"

--- a/job-node.yaml
+++ b/job-node.yaml
@@ -12,8 +12,17 @@ spec:
           image: aquasec/kube-bench:latest
           command: ["kube-bench", "node"]
           volumeMounts:
+            - name: var-lib-etcd
+              mountPath: /var/lib/etcd
+              readOnly: true
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
+              readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
               readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
@@ -32,11 +41,26 @@ spec:
             - name: usr-bin
               mountPath: /usr/local/mount-from-host/bin
               readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
       restartPolicy: Never
       volumes:
+        - name: var-lib-etcd
+          hostPath:
+            path: "/var/lib/etcd"
         - name: var-lib-kubelet
           hostPath:
             path: "/var/lib/kubelet"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
         - name: etc-systemd
           hostPath:
             path: "/etc/systemd"
@@ -52,3 +76,9 @@ spec:
         - name: usr-bin
           hostPath:
             path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"

--- a/job.yaml
+++ b/job.yaml
@@ -21,8 +21,20 @@ spec:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet
               readOnly: true
+            - name: var-lib-kube-scheduler
+              mountPath: /var/lib/kube-scheduler
+              readOnly: true
+            - name: var-lib-kube-controller-manager
+              mountPath: /var/lib/kube-controller-manager
+              readOnly: true
             - name: etc-systemd
               mountPath: /etc/systemd
+              readOnly: true
+            - name: lib-systemd
+              mountPath: /lib/systemd/
+              readOnly: true
+            - name: srv-kubernetes
+              mountPath: /srv/kubernetes/
               readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
@@ -32,6 +44,12 @@ spec:
             - name: usr-bin
               mountPath: /usr/local/mount-from-host/bin
               readOnly: true
+            - name: etc-cni-netd
+              mountPath: /etc/cni/net.d/
+              readOnly: true
+            - name: opt-cni-bin
+              mountPath: /opt/cni/bin/
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-etcd
@@ -40,12 +58,30 @@ spec:
         - name: var-lib-kubelet
           hostPath:
             path: "/var/lib/kubelet"
+        - name: var-lib-kube-scheduler
+          hostPath:
+            path: "/var/lib/kube-scheduler"
+        - name: var-lib-kube-controller-manager
+          hostPath:
+            path: "/var/lib/kube-controller-manager"
         - name: etc-systemd
           hostPath:
             path: "/etc/systemd"
+        - name: lib-systemd
+          hostPath:
+            path: "/lib/systemd"
+        - name: srv-kubernetes
+          hostPath:
+            path: "/srv/kubernetes"
         - name: etc-kubernetes
           hostPath:
             path: "/etc/kubernetes"
         - name: usr-bin
           hostPath:
             path: "/usr/bin"
+        - name: etc-cni-netd
+          hostPath:
+            path: "/etc/cni/net.d/"
+        - name: opt-cni-bin
+          hostPath:
+            path: "/opt/cni/bin/"


### PR DESCRIPTION
Running Kube-bench in kops clusters provide a lot of false-positive alerts, so such automation allows kube-bench search files and test them in addition to the list of known places in the config file. 
Signed-off-by: Dmytro Oboznyi <dmytro.oboznyi@syncier.com>

Ref #634