### PR TITLE
Improve: Allow kube-bench to scan Bottlerocket OS

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -121,11 +121,13 @@ node:
       - "/etc/kubernetes/kubelet.conf"
       - "/var/lib/kubelet/kubeconfig"
       - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/etc/kubernetes/kubelet/kubeconfig"
       - "/var/snap/microk8s/current/credentials/kubelet.config"
     confs:
       - "/var/lib/kubelet/config.yaml"
       - "/var/lib/kubelet/config.yml"
       - "/etc/kubernetes/kubelet/kubelet-config.json"
+      - "/etc/kubernetes/kubelet/config"
       - "/home/kubernetes/kubelet-config.yaml"
       - "/home/kubernetes/kubelet-config.yml"
       - "/etc/default/kubelet"
@@ -162,6 +164,7 @@ node:
       - /var/snap/microk8s/current/args/kube-proxy
     kubeconfig:
       - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/etc/kubernetes/kubelet/config"
       - "/var/lib/kubelet/kubeconfig"
       - "/var/snap/microk8s/current/credentials/proxy.config"
     svc:


### PR DESCRIPTION
**Summary**

Issue #808 

This PR update kube-bench configs to support Bottlerocket OS scanning.

These were my results:

**Before applying the changes requested**

```
== Summary node ==
1 checks PASS
13 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
1 checks PASS
13 checks FAIL
1 checks WARN
0 checks INFO
```

**After applying the changes requested**
```
== Summary node ==
12 checks PASS
2 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
12 checks PASS
2 checks FAIL
1 checks WARN
0 checks INFO
```

**After building a new Bottlerocket AMI that fixes those failed items reported by kube-bench**
```
== Summary node ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO
```

Thanks for reviewing! :)

PS: Thanks to @gregdek for the support