### PR TITLE
chore: fix defer func in for-loop

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -195,17 +195,19 @@ func TestIsMaster(t *testing.T) {
 	defer restore()
 
 	for _, tc := range testCases {
-		cfgFile = tc.cfgFile
-		initConfig()
+		func() {
+			cfgFile = tc.cfgFile
+			initConfig()
 
-		oldGetBinariesFunc := getBinariesFunc
-		getBinariesFunc = tc.getBinariesFunc
-		defer func() {
-			getBinariesFunc = oldGetBinariesFunc
-			cfgFile = ""
+			oldGetBinariesFunc := getBinariesFunc
+			getBinariesFunc = tc.getBinariesFunc
+			defer func() {
+				getBinariesFunc = oldGetBinariesFunc
+				cfgFile = ""
+			}()
+
+			assert.Equal(t, tc.isMaster, isMaster(), tc.name)
 		}()
-
-		assert.Equal(t, tc.isMaster, isMaster(), tc.name)
 	}
 }
 
@@ -506,17 +508,19 @@ func TestIsEtcd(t *testing.T) {
 	defer restore()
 
 	for _, tc := range testCases {
-		cfgFile = tc.cfgFile
-		initConfig()
+		func() {
+			cfgFile = tc.cfgFile
+			initConfig()
 
-		oldGetBinariesFunc := getBinariesFunc
-		getBinariesFunc = tc.getBinariesFunc
-		defer func() {
-			getBinariesFunc = oldGetBinariesFunc
-			cfgFile = ""
+			oldGetBinariesFunc := getBinariesFunc
+			getBinariesFunc = tc.getBinariesFunc
+			defer func() {
+				getBinariesFunc = oldGetBinariesFunc
+				cfgFile = ""
+			}()
+
+			assert.Equal(t, tc.isEtcd, isEtcd(), tc.name)
 		}()
-
-		assert.Equal(t, tc.isEtcd, isEtcd(), tc.name)
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -52,7 +52,10 @@ var runCmd = &cobra.Command{
 
 		// Merge version-specific config if any.
 		path := filepath.Join(cfgDir, bv)
-		mergeConfig(path)
+		err = mergeConfig(path)
+		if err != nil {
+			fmt.Printf("Error in mergeConfig: %v\n", err)
+		}
 
 		err = run(targets, bv)
 		if err != nil {


### PR DESCRIPTION
`defer` executes at function return, not out of block scope, so we should wrap `for` block by function.