### PR TITLE
docs: remove deprecated subcommands master / node

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Table of Contents
   - [CIS Kubernetes Benchmark support](#cis-kubernetes-benchmark-support)
   - [Installation](#installation)
   - [Running kube-bench](#running-kube-bench)
+    - [Specifying the benchmark or Kubernetes version](#specifying-the-benchmark-or-kubernetes-version)
+    - [Specifying Benchmark sections](#specifying-benchmark-sections)
     - [Running inside a container](#running-inside-a-container)
     - [Running in a Kubernetes cluster](#running-in-a-kubernetes-cluster)
     - [Running in an AKS cluster](#running-in-an-aks-cluster)
@@ -76,6 +78,8 @@ kube-bench supports the tests for Kubernetes as defined in the [CIS Kubernetes B
 
 By default, kube-bench will determine the test set to run based on the Kubernetes version running on the machine, but please note that kube-bench does not automatically detect OpenShift and GKE - see the section below on [Running kube-bench](https://github.com/aquasecurity/kube-bench#running-kube-bench).
 
+The test files for the various versions of CIS Benchmark can be found in directories
+with same name as the CIS Benchmark versions under `cfg/`, for example `cfg/cis-1.5`.
 ## Installation
 
 You can choose to
@@ -88,44 +92,46 @@ You can choose to
 
 If you run kube-bench directly from the command line you may need to be root / sudo to have access to all the config files.
 
-kube-bench automatically selects which `controls` to use based on the detected
-node type and the version of Kubernetes a cluster is running. This behavior
-can be overridden by specifying the `master` or `node` subcommand and the
-`--version` flag on the command line.
+By default kube-bench attempts to auto-detect the running version of Kubernetes, and map this to the corresponding CIS Benchmark version. For example, Kubernetes version 1.15 is mapped to CIS Benchmark version `cis-1.15` which is the benchmark version valid for Kubernetes 1.15.
 
+kube-bench also attempts to identify the components running on the node, and uses this to determine which tests to run (for example, only running the master node tests if the node is running an API server). 
 
-The Kubernetes version can also be set with the `KUBE_BENCH_VERSION` environment variable.
-The value of `--version` takes precedence over the value of `KUBE_BENCH_VERSION`.
+### Specifying the benchmark or Kubernetes version
 
-For example, run kube-bench against a master with version auto-detection:
+kube-bench uses the Kubernetes API, or access to the `kubectl` or `kubelet` executables to try to determine the Kubernetes version, and hence which benchmark to run. If you wish to override this, or if none of these methods are available, you can specify either the Kubernetes version or CIS Benchmark as a command line parameter.  
 
-```
-kube-bench master
-```
-
-Or run kube-bench against a worker node using the tests for Kubernetes version 1.13:
+You can specify `--benchmark` to run a specific CIS Benchmark version:
 
 ```
-kube-bench node --version 1.13
+kube-bench --benchmark cis-1.5
 ```
 
-`kube-bench` will map the `--version` to the corresponding CIS Benchmark version as indicated by the mapping table above. For example, if you specify `--version 1.15`, this is mapped to CIS Benchmark version `cis-1.15`.
+Alternatively you can specify a particular version of Kubernetes by setting the `--version` flag or with the `KUBE_BENCH_VERSION` environment variable. The value of `--version` takes precedence over the value of `KUBE_BENCH_VERSION`.
 
-Alternatively, you can specify `--benchmark` to run a specific CIS Benchmark version:
+For example, run kube-bench using the tests for Kubernetes version 1.13:
 
 ```
-kube-bench node --benchmark cis-1.5
+kube-bench --version 1.13
 ```
 
-If you want to target specific CIS Benchmark `target` (i.e master, node, etcd, etc...)
+**Note:**  It is an error to specify both `--version` and `--benchmark` flags together
+
+### Specifying Benchmark sections
+
+If you want to run specific CIS Benchmark sections (i.e master, node, etcd, etc...)
 you can use the `run --targets` subcommand.
+
 ```
 kube-bench --benchmark cis-1.5 run --targets master,node
 ```
+
 or
+
 ```
 kube-bench --benchmark cis-1.5 run --targets master,node,etcd,policies
 ```
+
+Check the contents of the benchmark directory under `cfg` to see which targets are available for that benchmark. Each file except `config.yaml` represents a target (also known as a `control` in other parts of this documentation). 
 
 The following table shows the valid targets based on the CIS Benchmark version.
 | CIS Benchmark | Targets |
@@ -135,39 +141,30 @@ The following table shows the valid targets based on the CIS Benchmark version.
 | gke-1.0| master, controlplane, node, etcd, policies, managedservices |
 | eks-1.0| controlplane, node, policies, managedservices |
 
-If no targets are specified, `kube-bench` will determine the appropriate targets based on the CIS Benchmark version.
-
-`controls` for the various versions of CIS Benchmark can be found in directories
-with same name as the CIS Benchmark versions under `cfg/`, for example `cfg/cis-1.5`.
-
-**Note:**  **`It is an error to specify both --version and --benchmark flags together`**
-
+If no targets are specified, `kube-bench` will determine the appropriate targets based on the CIS Benchmark version and the components detected on the node. The detection is done by verifying which components are running, as defined in the config files (see [Configuration](#configuration).
 ### Running inside a container
 
 You can avoid installing kube-bench on the host by running it inside a container using the host PID namespace and mounting the `/etc` and `/var` directories where the configuration and other files are located on the host so that kube-bench can check their existence and permissions.
 
 ```
-docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -t aquasec/kube-bench:latest [master|node] --version 1.13
+docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -t aquasec/kube-bench:latest --version 1.13
 ```
 
 > Note: the tests require either the kubelet or kubectl binary in the path in order to auto-detect the Kubernetes version. You can pass `-v $(which kubectl):/usr/local/mount-from-host/bin/kubectl` to resolve this. You will also need to pass in kubeconfig credentials. For example:
 
 ```
-docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -v $(which kubectl):/usr/local/mount-from-host/bin/kubectl -v ~/.kube:/.kube -e KUBECONFIG=/.kube/config -t aquasec/kube-bench:latest [master|node]
+docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -v $(which kubectl):/usr/local/mount-from-host/bin/kubectl -v ~/.kube:/.kube -e KUBECONFIG=/.kube/config -t aquasec/kube-bench:latest 
 ```
 
 You can use your own configs by mounting them over the default ones in `/opt/kube-bench/cfg/`
 
 ```
-docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -t -v path/to/my-config.yaml:/opt/kube-bench/cfg/config.yam -v $(which kubectl):/usr/local/mount-from-host/bin/kubectl -v ~/.kube:/.kube -e KUBECONFIG=/.kube/config aquasec/kube-bench:latest [master|node]
+docker run --pid=host -v /etc:/etc:ro -v /var:/var:ro -t -v path/to/my-config.yaml:/opt/kube-bench/cfg/config.yam -v $(which kubectl):/usr/local/mount-from-host/bin/kubectl -v ~/.kube:/.kube -e KUBECONFIG=/.kube/config aquasec/kube-bench:latest
 ```
 
 ### Running in a Kubernetes cluster
 
 You can run kube-bench inside a pod, but it will need access to the host's PID namespace in order to check the running processes, as well as access to some directories on the host where config files and other files are stored.
-
-Master nodes are automatically detected by kube-bench and will run master checks when possible.
-The detection is done by verifying that mandatory components for master, as defined in the config files, are running (see [Configuration](#configuration)).
 
 The supplied `job.yaml` file can be applied to run the tests as a job. For example:
 
@@ -191,13 +188,9 @@ kubectl logs kube-bench-j76s9
 ...
 ```
 
-You can still force to run specific master or node checks using respectively `job-master.yaml` and `job-node.yaml`.
-
-To run the tests on the master node, the pod needs to be scheduled on that node. This involves setting a nodeSelector and tolerations in the pod spec.
+To run tests on the master node, the pod needs to be scheduled on that node. This involves setting a nodeSelector and tolerations in the pod spec.
 
 The default labels applied to master nodes has changed since Kubernetes 1.11, so if you are using an older version you may need to modify the nodeSelector and tolerations to run the job on the master node.
-
-
 ### Running in an AKS cluster
 
 1. Create an AKS cluster(e.g. 1.13.7) with RBAC enabled, otherwise there would be 4 failures
@@ -212,7 +205,7 @@ could open nsg 22 port and assign a public ip for one agent node (only for testi
 1. Run CIS benchmark to view results:
 ```
 docker run --rm -v `pwd`:/host aquasec/kube-bench:latest install
-./kube-bench node
+./kube-bench 
 ```
 kube-bench cannot be run on AKS master nodes
 
@@ -282,7 +275,7 @@ This command copies the kube-bench binary and configuration files to your host f
 docker run --rm -v `pwd`:/host aquasec/kube-bench:latest install
 ```
 
-You can then run `./kube-bench [master|node]`.
+You can then run `./kube-bench`.
 
 ### Download and Install binaries
 
@@ -318,12 +311,12 @@ tar -xvf kube-bench_0.3.1_linux_amd64.tar.gz
 
 You can then run kube-bench directly:
 ```
-kube-bench [master|node]
+kube-bench
 ```
 
 If you manually downloaded the kube-bench binary (using curl command above), you have to specify the location of configuration directory and file. For example:
 ```
-./kube-bench --config-dir `pwd`/cfg --config `pwd`/cfg/config.yaml [master|node]
+./kube-bench --config-dir `pwd`/cfg --config `pwd`/cfg/config.yaml 
 ```
 
 See previous section on [Running kube-bench](#running-kube-bench) for further details on using the kube-bench binary.

--- a/README.md
+++ b/README.md
@@ -100,18 +100,19 @@ kube-bench also attempts to identify the components running on the node, and use
 
 kube-bench uses the Kubernetes API, or access to the `kubectl` or `kubelet` executables to try to determine the Kubernetes version, and hence which benchmark to run. If you wish to override this, or if none of these methods are available, you can specify either the Kubernetes version or CIS Benchmark as a command line parameter.  
 
-You can specify `--benchmark` to run a specific CIS Benchmark version:
-
-```
-kube-bench --benchmark cis-1.5
-```
-
-Alternatively you can specify a particular version of Kubernetes by setting the `--version` flag or with the `KUBE_BENCH_VERSION` environment variable. The value of `--version` takes precedence over the value of `KUBE_BENCH_VERSION`.
+You can specify a particular version of Kubernetes by setting the `--version` flag or with the `KUBE_BENCH_VERSION` environment variable. The value of `--version` takes precedence over the value of `KUBE_BENCH_VERSION`.
 
 For example, run kube-bench using the tests for Kubernetes version 1.13:
 
 ```
 kube-bench --version 1.13
+```
+
+
+You can specify `--benchmark` to run a specific CIS Benchmark version:
+
+```
+kube-bench --benchmark cis-1.5
 ```
 
 **Note:**  It is an error to specify both `--version` and `--benchmark` flags together
@@ -122,13 +123,13 @@ If you want to run specific CIS Benchmark sections (i.e master, node, etcd, etc.
 you can use the `run --targets` subcommand.
 
 ```
-kube-bench --benchmark cis-1.5 run --targets master,node
+kube-bench run --targets master,node
 ```
 
 or
 
 ```
-kube-bench --benchmark cis-1.5 run --targets master,node,etcd,policies
+kube-bench run --targets master,node,etcd,policies
 ```
 
 Check the contents of the benchmark directory under `cfg` to see which targets are available for that benchmark. Each file except `config.yaml` represents a target (also known as a `control` in other parts of this documentation). 


### PR DESCRIPTION
Example commands should use auto-detection or the new `run --targets` approach to specifying sections of the benchmark to run