### PR TITLE
Fix fallback to default version

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -358,7 +358,7 @@ func TestGetBenchmarkVersion(t *testing.T) {
 		succeed          bool
 	}{
 		{n: "both versions", kubeVersion: "1.11", benchmarkVersion: "cis-1.3", exp: "cis-1.3", callFn: withNoPath, v: viper.New(), succeed: false},
-		{n: "no version-missing-kubectl", kubeVersion: "", benchmarkVersion: "", v: viperWithData, exp: "", callFn: withNoPath, succeed: false},
+		{n: "no version-missing-kubectl", kubeVersion: "", benchmarkVersion: "", v: viperWithData, exp: "cis-1.6", callFn: withNoPath, succeed: true},
 		{n: "no version-fakeKubectl", kubeVersion: "", benchmarkVersion: "", v: viperWithData, exp: "cis-1.5", callFn: withFakeKubectl, succeed: true},
 		{n: "kubeVersion", kubeVersion: "1.15", benchmarkVersion: "", v: viperWithData, exp: "cis-1.5", callFn: withNoPath, succeed: true},
 		{n: "ocpVersion310", kubeVersion: "ocp-3.10", benchmarkVersion: "", v: viperWithData, exp: "rh-0.7", callFn: withNoPath, succeed: true},

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -304,7 +304,9 @@ func getKubeVersion() (*KubeVersion, error) {
 			}
 
 			glog.Warning(missingKubectlKubeletMessage)
-			return nil, fmt.Errorf("unable to find the programs kubectl or kubelet in the PATH")
+			glog.V(1).Info("unable to find the programs kubectl or kubelet in the PATH")
+			glog.V(1).Infof("Cant detect version, assuming default %s", defaultKubeVersion)
+			return &KubeVersion{baseVersion: defaultKubeVersion}, nil 
 		}
 		return getKubeVersionFromKubelet(), nil
 	}


### PR DESCRIPTION
In some cases kube-bench will crush instead of fallback to default version. 
Fix it to only log that couldn't auto-detect version and used default.