### PR TITLE
Issue 867: Fixing "No such file or directory" issue seen with CIS 1.1.9 and 1.1.0

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -122,7 +122,7 @@ groups:
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a
-          find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -140,7 +140,7 @@ groups:
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c %U:%G
-          find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
           test_items:


### PR DESCRIPTION
This PR covers the issue documented in #867 whereby CIS 1.1.9 ( and also 1.1.10 ) throw a WARNing for `/var/lib/cni/networks` in terms of permissions ( `chown` and `chmod` ), even though the same command, when run locally on the K8s nodes does not return an error.

#867 describes the issue in more detail but, in short, we see: -

```text
I0504 17:36:02.705809   21516 check.go:110] -----   Running check 1.1.9   -----
I0504 17:36:02.712997   21516 check.go:299] Command: "ps -ef | grep kubelet | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\\([^ ]*\\).*%\\1%' | xargs -I{} find {} -mindepth 1 | xargs stat -c permissions=%a\nfind /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a"
I0504 17:36:02.713018   21516 check.go:300] Output:
 "permissions=644\npermissions=644\nfind: /var/lib/cni/networks: No such file or directory\n"
```

in the verbose `kube-bench` logs which results in WARNings for both `1.1.9` and `1.1.10` even though permissions and ownership of `/var/lib/cni/networks` are A-OK.

The issue relates to the second audit command - `    find /var/lib/cni/networks -type f | xargs --no-run-if-empty stat -c permissions=%a` - which returns "No such file or directory", but *only* when run via `kube-bench`.

The mitigation is to add output redirection - `2> /dev/null` to the `find` command.

This has been most recently tested using K8s `1.21` on Linux on IBM Z ( `s390x` ), by manually amending `cfg/cis-1.6/master.yaml` and building a new `kube-bench` image.

Signed-off by: Dave Hay <david_hay@uk.ibm.com>