### PR TITLE
Allow kube-bench to scan Bottlerocket OS

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -140,11 +140,13 @@ node:
       - "/etc/kubernetes/kubelet.conf"
       - "/var/lib/kubelet/kubeconfig"
       - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/etc/kubernetes/kubelet/kubeconfig"
       - "/var/snap/microk8s/current/credentials/kubelet.config"
     confs:
       - "/var/lib/kubelet/config.yaml"
       - "/var/lib/kubelet/config.yml"
       - "/etc/kubernetes/kubelet/kubelet-config.json"
+      - "/etc/kubernetes/kubelet/config"
       - "/home/kubernetes/kubelet-config.yaml"
       - "/home/kubernetes/kubelet-config.yml"
       - "/etc/default/kubeletconfig.json"
@@ -183,6 +185,7 @@ node:
       - /var/snap/microk8s/current/args/kube-proxy
     kubeconfig:
       - "/etc/kubernetes/kubelet-kubeconfig"
+      - "/etc/kubernetes/kubelet/config"
       - "/var/lib/kubelet/kubeconfig"
       - "/var/snap/microk8s/current/credentials/proxy.config"
     svc:


### PR DESCRIPTION
Fixes #887

Before:

```
== Summary node ==
1 checks PASS
13 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
1 checks PASS
13 checks FAIL
1 checks WARN
0 checks INFO
```

After:

```
== Summary node ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO

== Summary total ==
14 checks PASS
0 checks FAIL
1 checks WARN
0 checks INFO
```