### PR TITLE
cis-1.20 section 1.1.10 command revision.

### DIFF
--- a/cfg/cis-1.20/master.yaml
+++ b/cfg/cis-1.20/master.yaml
@@ -139,7 +139,7 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs xargs --no-run-if-empty stat -c %U:%G
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:


### PR DESCRIPTION
An erroneous xargs statement resulting in an empty response when running the audit command.