### PR TITLE
Add node kubelet config path

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -143,6 +143,7 @@ node:
       - "/etc/kubernetes/kubelet/kubeconfig"
       - "/var/snap/microk8s/current/credentials/kubelet.config"
     confs:
+      - "/etc/kubernetes/kubelet-config.yaml"
       - "/var/lib/kubelet/config.yaml"
       - "/var/lib/kubelet/config.yml"
       - "/etc/kubernetes/kubelet/kubelet-config.json"


### PR DESCRIPTION
In kubespray tool we have another path for kubelet config, add them to kube-bench config on top

Issue: #948