### PR TITLE
[WIP] Add multiarch container publishing via goreleaser

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,8 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v3
         with:
           images: ${{ env.REP }}
-          tag-semver: |
-            {{version}}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and push - Docker/ECR
         id: docker_build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "v*"
 env:
-  ALIAS: jonshaffer
+  ALIAS: u7i1e6j3
   DOCKERHUB_ALIAS: hyperjon
   REP: kube-bench
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,8 @@ on:
     tags:
       - "v*"
 env:
-  ALIAS: aquasecurity
-  DOCKERHUB_ALIAS: aquasec
+  ALIAS: jonshaffer
+  DOCKERHUB_ALIAS: jonshaffer
   REP: kube-bench
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 env:
   ALIAS: jonshaffer
-  DOCKERHUB_ALIAS: jonshaffer
+  DOCKERHUB_ALIAS: hyperjon
   REP: kube-bench
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+env:
+  KIND_VERSION: "v0.11.1"
+  KIND_IMAGE: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
 jobs:
   release:
     name: Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,9 +16,34 @@ builds:
       - 6
       - 7
     ldflags:
-      - "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion={{.Version}}"
-      - "-X github.com/aquasecurity/kube-bench/cmd.cfgDir={{.Env.KUBEBENCH_CFG}}"
+      - "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion={{.Version}}"
+      - "-X github.com/jonshaffer/kube-bench/cmd.cfgDir={{.Env.KUBEBENCH_CFG}}"
 # Archive customization
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    use: docker
+    build_flag_templates:
+    - "--build-arg=GOOS=linux"
+    - "--build-arg=GOARCH=amd64"
+  -
+    goos: linux
+    goarch: arm
+    dockerfile: Dockerfile
+    use: docker
+    build_flag_templates:
+    - "--build-arg=GOOS=linux"
+    - "--build-arg=GOARCH=arm"
+  -
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: docker
+    build_flag_templates:
+    - "--build-arg=GOOS=linux"
+    - "--build-arg=GOARCH=arm64"
 archives:
   - id: default
     format: tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ env:
   - KUBEBENCH_CFG=/etc/kube-bench/cfg
 builds:
   - main: main.go
+    env:
+    - CGO_ENABLED=0
     binary: kube-bench
     goos:
       - linux
@@ -22,32 +24,37 @@ builds:
 dockers:
   -
     image_templates:
-    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
-    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
-    - "hyperjon/kube-bench:latest"
-    - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
+    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}-amd64"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}-amd64"
+    # - "hyperjon/kube-bench:latest"
+    # - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile
-    use: docker
+    use: buildx
     build_flag_templates:
     - "--build-arg=GOOS=linux"
     - "--build-arg=GOARCH=amd64"
     - "--platform=linux/amd64"
   -
     image_templates:
-    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
-    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
-    - "hyperjon/kube-bench:latest"
-    - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
+    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}-arm64v8"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}-arm64v8"
+    # - "hyperjon/kube-bench:latest"
+    # - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
     goos: linux
     goarch: arm64
     dockerfile: Dockerfile
-    use: docker
+    use: buildx
     build_flag_templates:
     - "--build-arg=GOOS=linux"
     - "--build-arg=GOARCH=arm64"
-    - "--platform=linux/arm64"
+    - "--platform=linux/arm64/v8"
+docker_manifests:
+- name_template: hyperjon/kube-bench:v{{.Version}}
+  image_templates:
+  - hyperjon/kube-bench:v{{.Version}}-amd64
+  - gyperjon/kube-bench:v{{.Version}}-arm64v8
 archives:
   - id: default
     format: tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,11 @@ builds:
 # Archive customization
 dockers:
   -
+    image_templates:
+    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
+    - "hyperjon/kube-bench:latest"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile
@@ -28,15 +33,13 @@ dockers:
     build_flag_templates:
     - "--build-arg=GOOS=linux"
     - "--build-arg=GOARCH=amd64"
+    - "--platform=linux/amd64"
   -
-    goos: linux
-    goarch: arm
-    dockerfile: Dockerfile
-    use: docker
-    build_flag_templates:
-    - "--build-arg=GOOS=linux"
-    - "--build-arg=GOARCH=arm"
-  -
+    image_templates:
+    - "hyperjon/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:v{{.Version}}-SNAPSHOT-{{.ShortCommit}}"
+    - "hyperjon/kube-bench:latest"
+    - "public.ecr.aws/u7i1e6j3/kube-bench:latest"
     goos: linux
     goarch: arm64
     dockerfile: Dockerfile
@@ -44,6 +47,7 @@ dockers:
     build_flag_templates:
     - "--build-arg=GOOS=linux"
     - "--build-arg=GOARCH=arm64"
+    - "--platform=linux/arm64"
 archives:
   - id: default
     format: tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ COPY main.go .
 COPY check/ check/
 COPY cmd/ cmd/
 COPY internal/ internal/
-ARG KUBEBENCH_VERSION
-ARG GOOS=linux
-ENV ENV_GOOS=${GOOS}
-ARG GOARCH=amd64
-ENV ENV_GOARCH=${ENV_GOARCH}
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$ENV_GOOS GOARCH=$ENV_GOARCH go build -a -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
+# ARG KUBEBENCH_VERSION
+# ARG GOOS=linux
+# ENV ENV_GOOS=${GOOS}
+# ARG GOARCH=amd64
+# ENV ENV_GOARCH=${ENV_GOARCH}
+# RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$ENV_GOOS GOARCH=$ENV_GOARCH go build -a -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
+
+COPY kube-bench /go/bin/kube-bench
 
 FROM alpine:3.14.2 AS run
 WORKDIR /opt/kube-bench/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 ARG KUBEBENCH_VERSION
 ARG GOOS=linux
+ENV ENV_GOOS=${GOOS}
 ARG GOARCH=amd64
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -a -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
+ENV ENV_GOARCH=${ENV_GOARCH}
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$ENV_GOOS GOARCH=$ENV_GOARCH go build -a -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
 
 FROM alpine:3.14.2 AS run
 WORKDIR /opt/kube-bench/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.17.0 AS build
-WORKDIR /go/src/github.com/aquasecurity/kube-bench/
+WORKDIR /go/src/github.com/jonshaffer/kube-bench/
 COPY go.mod go.sum ./
 COPY main.go .
 COPY check/ check/
@@ -8,7 +8,7 @@ COPY internal/ internal/
 ARG KUBEBENCH_VERSION
 ARG GOOS=linux
 ARG GOARCH=amd64
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -a -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -a -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=${KUBEBENCH_VERSION} -w" -o /go/bin/kube-bench
 
 FROM alpine:3.14.2 AS run
 WORKDIR /opt/kube-bench/

--- a/makefile
+++ b/makefile
@@ -46,7 +46,7 @@ manifests:
 build: $(BINARY)
 
 $(BINARY): $(SOURCES)
-	GOOS=$(GOOS) go build -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=$(KUBEBENCH_VERSION)" -o $(BINARY) .
+	GOOS=$(GOOS) go build -ldflags "-X github.com/jonshaffer/kube-bench/cmd.KubeBenchVersion=$(KUBEBENCH_VERSION)" -o $(BINARY) .
 
 # builds the current dev docker version
 build-docker:

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 SOURCES := $(shell find . -name '*.go')
 BINARY := kube-bench
-DOCKER_ORG ?= aquasec
+DOCKER_ORG ?= hyperjon
 VERSION ?= $(shell git rev-parse --short=7 HEAD)
 KUBEBENCH_VERSION ?= $(shell git describe --tags --abbrev=0)
 IMAGE_NAME ?= $(DOCKER_ORG)/$(BINARY):$(VERSION)


### PR DESCRIPTION
Hi, I ran into this issue #963 and really wanted to run this project on my local pi cluster while studying for the CKS. I spent a little while and have got a working example starting at docker.io `hyperjon/kube-bench:0.6.5-beta.8`. I found no related discussion.

Before change:
- Publish / binary release are separate
- Only publishing amd64 support to dockerhub + ECR

After change:
- Publish / binary release are part of the same goreleaser command
- Arm64 and other distributions easily added

I would love some feedback!