### PR TITLE
Add a trailing slash to find directory path

### DIFF
--- a/cfg/cis-1.20/master.yaml
+++ b/cfg/cis-1.20/master.yaml
@@ -278,7 +278,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "find /etc/kubernetes/pki -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -294,7 +294,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki -name '*.key' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -278,7 +278,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "find /etc/kubernetes/pki -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -294,7 +294,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki -name '*.key' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:


### PR DESCRIPTION
This transplants #687 to cis-1.6 and cis-1.20. Fixes #686 for cis-1.6 and cis-1.20.