### PR TITLE
Fix find pid of running program

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -138,7 +138,7 @@ func generateDefaultEnvAudit(controls *check.Controls, binSubs []string) {
 						}
 
 						if test.Env != "" && checkItem.AuditEnv == "" {
-							checkItem.AuditEnv = fmt.Sprintf("cat \"/proc/$(/bin/ps -C %s -o pid= | tr -d ' ')/environ\" | tr '\\0' '\\n'", binPath)
+							checkItem.AuditEnv = fmt.Sprintf("cat \"/proc/$(/bin/pidof %s)/environ\" | tr '\\0' '\\n'", binPath)
 						}
 					}
 				}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -638,7 +638,7 @@ groups:
 	binSubs := []string{"TestBinPath"}
 	generateDefaultEnvAudit(controls, binSubs)
 
-	expectedAuditEnv := fmt.Sprintf("cat \"/proc/$(/bin/ps -C %s -o pid= | tr -d ' ')/environ\" | tr '\\0' '\\n'", binSubs[0])
+	expectedAuditEnv := fmt.Sprintf("cat \"/proc/$(/bin/pidof %s)/environ\" | tr '\\0' '\\n'", binSubs[0])
 	assert.Equal(t, expectedAuditEnv, controls.Groups[1].Checks[0].AuditEnv)
 }
 


### PR DESCRIPTION
this PR fix issue https://github.com/aquasecurity/kube-bench/issues/828
use `pidof` insted `/bin/ps -C etcd -o pid=` 