### PR TITLE
Allow for usage of env var `K8S_HOST` in psql

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -77,7 +77,7 @@ func (c *PsqlConnInfo) toString() string {
 func savePgsql(jsonInfo string) {
 	var hostname string
 	if value := viper.GetString("K8S_HOST"); value != "" {
-		// Adhere to the ScanHost column definition bellow
+		// Adhere to the ScanHost column definition below
 		if len(value) > 63 {
 			exitWithError(fmt.Errorf("%s_K8S_HOST value's length must be less than 63 chars", envVarsPrefix))
 		}


### PR DESCRIPTION
Hi! 

First and foremost, thank you for this project!

I'm doing a POC at my org and I'd like to use the psql output integration. Initial testing shows that the hostname value in the column is literally just that. The pod name,

I manage several clusters and would like the output in the same database but it would be confusing with no way to differentiate them aside from renaming the cronjob to some clumsy value.

Please let me know your thoughts.

Regards,
Zhak