### PR TITLE
Fix the `--exit-code` flag doesn't work when run with subcommand

### DIFF
--- a/cmd/master.go
+++ b/cmd/master.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ var masterCmd = &cobra.Command{
 		filename := loadConfig(check.MASTER, bv)
 		runChecks(check.MASTER, filename, detecetedKubeVersion)
 		writeOutput(controlsCollection)
+		os.Exit(exitCodeSelection(controlsCollection))
 	},
 	Deprecated: "this command will be retired soon. Please use the `run` command with `--targets=master` instead.",
 }

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aquasecurity/kube-bench/check"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ var nodeCmd = &cobra.Command{
 		filename := loadConfig(check.NODE, bv)
 		runChecks(check.NODE, filename, detecetedKubeVersion)
 		writeOutput(controlsCollection)
+		os.Exit(exitCodeSelection(controlsCollection))
 	},
 	Deprecated: "this command will be retired soon. Please use the `run` command with `--targets=node` instead.",
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,8 +136,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		writeOutput(controlsCollection)
-		exitCode := exitCodeSelection(controlsCollection)
-		os.Exit(exitCode)
+		os.Exit(exitCodeSelection(controlsCollection))
 	},
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,13 +54,15 @@ var runCmd = &cobra.Command{
 		path := filepath.Join(cfgDir, bv)
 		err = mergeConfig(path)
 		if err != nil {
-			fmt.Printf("Error in mergeConfig: %v\n", err)
+			exitWithError(fmt.Errorf("Error in mergeConfig: %v\n", err))
 		}
 
 		err = run(targets, bv)
 		if err != nil {
-			fmt.Printf("Error in run: %v\n", err)
+			exitWithError(fmt.Errorf("Error in run: %v\n", err))
 		}
+
+		os.Exit(exitCodeSelection(controlsCollection))
 	},
 }
 


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/kube-bench/issues/1000