### PR TITLE
ASFF: no longer include timestamp in the finding ID

### DIFF
--- a/check/controls.go
+++ b/check/controls.go
@@ -249,7 +249,7 @@ func (controls *Controls) ASFF() ([]*securityhub.AwsSecurityFinding, error) {
 					AwsAccountId:  aws.String(a),
 					Confidence:    aws.Int64(100),
 					GeneratorId:   aws.String(fmt.Sprintf("%s/cis-kubernetes-benchmark/%s/%s", arn, controls.Version, check.ID)),
-					Id:            aws.String(fmt.Sprintf("%s%sEKSnodeID+%s%s", arn, a, check.ID, tf)),
+					Id:            aws.String(fmt.Sprintf("%s%sEKSnodeID+%s", arn, a, check.ID)),
 					CreatedAt:     aws.String(tf),
 					Description:   aws.String(check.Text),
 					ProductArn:    aws.String(arn),


### PR DESCRIPTION
Fixes #1116

Before:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/485054/160223099-e5fbdd4e-21eb-45ef-922b-1d6b7acbd13a.png">

After:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/485054/160223137-e77b3198-0455-4d19-b632-f9199a733161.png">
