### PR TITLE
feat(schema): add database schema config

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -38,7 +38,7 @@ func getPsqlConnInfo() (PsqlConnInfo, error) {
 	if value := viper.GetString("PGSQL_DBNAME"); value != "" {
 		dbName = value
 	} else {
-		return PsqlConnInfo{}, fmt.Errorf("%s_PGSQL_USER env var is required", envVarsPrefix)
+		return PsqlConnInfo{}, fmt.Errorf("%s_PGSQL_DBNAME env var is required", envVarsPrefix)
 	}
 
 	var sslMode string

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -64,7 +64,7 @@ func getPsqlConnInfo() (PsqlConnInfo, error) {
 		schema = value
 	} else {
 		schema = ""
-		fmt.Printf("No schema set.")
+		glog.V(2).Info("No schema set.")
 	}
 
 	return PsqlConnInfo{

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -20,9 +20,6 @@ type PsqlConnInfo struct {
 	Password string
 	Schema   string
 }
-
-var db *gorm.DB
-
 func getPsqlConnInfo() (PsqlConnInfo, error) {
 	var host string
 	if value := viper.GetString("PGSQL_HOST"); value != "" {

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -20,6 +20,7 @@ type PsqlConnInfo struct {
 	Password string
 	Schema   string
 }
+
 func getPsqlConnInfo() (PsqlConnInfo, error) {
 	var host string
 	if value := viper.GetString("PGSQL_HOST"); value != "" {
@@ -106,6 +107,8 @@ func savePgsql(jsonInfo string) {
 	if err != nil {
 		exitWithError(err)
 	}
+
+	var db *gorm.DB
 
 	if PsqlConnInfo.Schema == "" {
 		db, err = gorm.Open(postgres.Open(PsqlConnInfo.toString()), &gorm.Config{})


### PR DESCRIPTION
With this configuration, you can select database schema. This setting could be good when you want to share the same Postgres instance for different clusters validations.