### PR TITLE
fix kube-bench/cfg/cis-1.6/master.yaml 1.2.26

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -714,7 +714,9 @@ groups:
       - id: 1.2.26
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
+        tests:
+          test_items:
+            - flag: "--request-timeout"
         remediation: |
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.


### PR DESCRIPTION
Add test to 1.2.26 to check that --request-timeout parameter is configured.