### PR TITLE
Update job-master.yaml for K8s 1.24.x labels/tolerations (#1250)

### DIFF
--- a/job-master.yaml
+++ b/job-master.yaml
@@ -7,10 +7,21 @@ spec:
   template:
     spec:
       hostPID: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
       tolerations:
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:


### PR DESCRIPTION
This is an attempt to fix issue described in #1250 -- however I'm not 100% on the approach, I would assume that you want backwards compatibility for K8s 1.23.x and below. Please advise about approach and I can make relevant amendments.