### PR TITLE
Add label to eks jobs

### DIFF
--- a/job-eks-asff.yaml
+++ b/job-eks-asff.yaml
@@ -26,6 +26,9 @@ metadata:
   name: kube-bench
 spec:
   template:
+    metadata:
+      labels:
+        app: kube-bench
     spec:
       hostPID: true
       containers:

--- a/job-eks.yaml
+++ b/job-eks.yaml
@@ -5,6 +5,9 @@ metadata:
   name: kube-bench
 spec:
   template:
+    metadata:
+      labels:
+        app: kube-bench
     spec:
       hostPID: true
       containers:


### PR DESCRIPTION
Adding label to eks jobs so we can inspect results using `kubectl logs --selector=app=kube-bench`