### PR TITLE
mount /etc/passwd and /etc/group for etcd ownership related checks

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -50,6 +50,12 @@ spec:
             - name: opt-cni-bin
               mountPath: /opt/cni/bin/
               readOnly: true
+            - name: etc-passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: etc-group
+              mountPath: /etc/group
+              readOnly: true
       restartPolicy: Never
       volumes:
         - name: var-lib-etcd
@@ -85,3 +91,9 @@ spec:
         - name: opt-cni-bin
           hostPath:
             path: "/opt/cni/bin/"
+        - name: etc-passwd
+          hostPath:
+            path: "/etc/passwd"
+        - name: etc-group
+          hostPath:
+            path: "/etc/group"


### PR DESCRIPTION
Changes to job-master.yaml are also needed in job.yaml to properly check ownership of etcd data dir

Issue: https://github.com/aquasecurity/kube-bench/issues/1275

Related to issue: https://github.com/aquasecurity/kube-bench/issues/842
fix the same as in https://github.com/aquasecurity/kube-bench/pull/868