### PR TITLE
Bumping glibc version to 2.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ RUN apk --no-cache upgrade apk-tools
 # Ensuring that we update/upgrade before installing openssl, to mitigate CVE-2021-3711 and CVE-2021-3712
 RUN apk update && apk upgrade && apk --no-cache add openssl
 
-# Add glibc for running oc command 
+# Add glibc for running oc command
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk
-RUN apk add glibc-2.33-r0.apk
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk
+RUN apk add glibc-2.35-r0.apk --force-overwrite
 RUN apk add jq
 
 ENV PATH=$PATH:/usr/local/mount-from-host/bin


### PR DESCRIPTION
Bumping glibc version to 2.35
Adding --force-overwrite to fix build error - trying to overwrite etc/nsswitch.conf owned by alpine-baselayout-data-3.2.0-r23

Fixes #1277 