### PR TITLE
fixed issue #1295 by making chavacava's suggestion

### DIFF
--- a/cmd/kubernetes_version_test.go
+++ b/cmd/kubernetes_version_test.go
@@ -264,10 +264,8 @@ func TestGetKubernetesURL(t *testing.T) {
 			}
 			k8sURL := getKubernetesURL()
 
-			if !c.useDefault {
-				if k8sURL != c.expected {
-					t.Errorf("Expected %q but Got %q", k8sURL, c.expected)
-				}
+			if k8sURL != c.expected {
+				t.Errorf("Expected %q but Got %q", k8sURL, c.expected)
 			}
 		})
 	}

--- a/cmd/kubernetes_version_test.go
+++ b/cmd/kubernetes_version_test.go
@@ -268,10 +268,6 @@ func TestGetKubernetesURL(t *testing.T) {
 				if k8sURL != c.expected {
 					t.Errorf("Expected %q but Got %q", k8sURL, c.expected)
 				}
-			} else {
-				if k8sURL != c.expected {
-					t.Errorf("Expected %q but Got %q", k8sURL, c.expected)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
[Issue #1295](https://github.com/aquasecurity/kube-bench/issues/1295) fixed by removing redundant `if !c.useDefault` condition.
All tests passing.