### PR TITLE
support customize datadir locations of etcd

### DIFF
--- a/cfg/cis-1.20/master.yaml
+++ b/cfg/cis-1.20/master.yaml
@@ -153,7 +153,13 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
         tests:
           test_items:
             - flag: "permissions"

--- a/cfg/cis-1.23/master.yaml
+++ b/cfg/cis-1.23/master.yaml
@@ -147,7 +147,13 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
         tests:
           test_items:
             - flag: "permissions"

--- a/cfg/cis-1.5/master.yaml
+++ b/cfg/cis-1.5/master.yaml
@@ -158,7 +158,13 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
         tests:
           test_items:
             - flag: "permissions"
@@ -176,7 +182,13 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c %U:%G $DATA_DIR
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -153,7 +153,13 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
         tests:
           test_items:
             - flag: "permissions"
@@ -170,7 +176,13 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c %U:%G $DATA_DIR
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -89,6 +89,9 @@ master:
     bins:
       - "etcd"
       - "openshift start etcd"
+    datadirs:
+      - /var/lib/etcd/default.etcd
+      - /var/lib/etcd/data.etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.yml
@@ -99,6 +102,7 @@ master:
       - /var/snap/microk8s/current/args/etcd
       - /usr/lib/systemd/system/etcd.service
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
+    defaultdatadir: /var/lib/etcd/default.etcd
 
   flanneld:
     optional: true
@@ -211,6 +215,9 @@ etcd:
   etcd:
     bins:
       - "etcd"
+    datadirs:
+      - /var/lib/etcd/default.etcd
+      - /var/lib/etcd/data.etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.yml
@@ -221,6 +228,7 @@ etcd:
       - /var/snap/microk8s/current/args/etcd
       - /usr/lib/systemd/system/etcd.service
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
+    defaultdatadir: /var/lib/etcd/default.etcd
 
 controlplane:
   components:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -96,6 +96,7 @@ func runChecks(nodetype check.NodeType, testYamlFile, detectedVersion string) {
 	svcmap := getFiles(typeConf, "service")
 	kubeconfmap := getFiles(typeConf, "kubeconfig")
 	cafilemap := getFiles(typeConf, "ca")
+	datadirmap := getFiles(typeConf, "datadir")
 
 	// Variable substitutions. Replace all occurrences of variables in controls files.
 	s := string(in)
@@ -104,6 +105,7 @@ func runChecks(nodetype check.NodeType, testYamlFile, detectedVersion string) {
 	s, _ = makeSubstitutions(s, "svc", svcmap)
 	s, _ = makeSubstitutions(s, "kubeconfig", kubeconfmap)
 	s, _ = makeSubstitutions(s, "cafile", cafilemap)
+	s, _ = makeSubstitutions(s, "datadir", datadirmap)
 
 	controls, err := check.NewControls(nodetype, []byte(s), detectedVersion)
 	if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -33,6 +33,7 @@ var (
 		"kubeconfig": {"kubeconfig", "defaultkubeconfig"},
 		"service":    {"svc", "defaultsvc"},
 		"config":     {"confs", "defaultconf"},
+		"datadir":    {"datadirs", "defaultdatadir"},
 	}
 )
 


### PR DESCRIPTION
Use this way to support cases:

* The etcd server startup with no `--data-dir` flag,  it will use default value(`${name}.etcd`) as data-dir
* The value of `--data-dir`  flag is a relative path. Closes #583

refer:

* https://etcd.io/docs/v3.5/op-guide/configuration/#command-line-flags