### PR TITLE
Fix to empty grep and other cis-1.6-k3s checks

### DIFF
--- a/cfg/cis-1.6-k3s/etcd.yaml
+++ b/cfg/cis-1.6-k3s/etcd.yaml
@@ -10,17 +10,15 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate if use etcd as database (Automated)"
-        audit: grep -E 'cert-file|key-file' $etcdconf
+        audit: grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file' 
         tests:
           bin_op: and
           test_items:
-            - flag: "--cert-file"
-              env: "ETCD_CERT_FILE"
-            - flag: "--key-file"
-              env: "ETCD_KEY_FILE"
+            - flag: "cert-file"
+            - flag: "key-file"
         remediation: |
           By default, K3s uses a config file for etcd that can be found at $etcdconf.
-          Server and peer cert and key files are specified. No manual remediation needed.
+          The config file contains client-transport-security: which has fields that have the peer cert and peer key files. No manual remediation needed.
         scored: true
 
       - id: 2.2
@@ -28,8 +26,7 @@ groups:
         audit: grep 'client-cert-auth' $etcdconf
         tests:
           test_items:
-            - flag: "--client-cert-auth"
-              env: "ETCD_CLIENT_CERT_AUTH"
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
@@ -40,15 +37,13 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: grep 'auto-tls' $etcdconf
+        audit: grep 'auto-tls' $etcdconf | cat
         tests:
           bin_op: or
           test_items:
-            - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
+            - flag: "auto-tls"
               set: false
-            - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
+            - flag: "auto-tls"
               compare:
                 op: eq
                 value: false
@@ -59,14 +54,12 @@ groups:
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
         set as appropriate (Automated)"
-        audit: grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'
+        audit: grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'
         tests:
           bin_op: and
           test_items:
-            - flag: "--peer-cert-file"
-              env: "ETCD_PEER_CERT_FILE"
-            - flag: "--peer-key-file"
-              env: "ETCD_PEER_KEY_FILE"
+            - flag: "cert-file"
+            - flag: "key-file"
         remediation: |
           By default, K3s starts Etcd with a config file found here, $etcdconf.
           The config file contains peer-transport-security: which has fields that have the peer cert and peer key files.
@@ -74,30 +67,27 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: grep 'client-cert-auth' $etcdconf
+        audit: grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'
         tests:
           test_items:
-            - flag: "--peer-client-cert-auth"
-              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
         remediation: |
           By default, K3s uses a config file for etcd that can be found at $etcdconf.
-          Within the file, the client-cert-auth field is set. No manual remediation needed.
+          The config file contains peer-transport-security: which has client-cert-auth set to true. No manual remediation needed.
         scored: true
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: grep 'peer-auto-tls' $etcdconf
+        audit: grep 'peer-auto-tls' $etcdconf | cat
         tests:
           bin_op: or
           test_items:
-            - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
+            - flag: "peer-auto-tls"
               set: false
-            - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
+            - flag: "peer-auto-tls"
               compare:
                 op: eq
                 value: false

--- a/cfg/cis-1.6-k3s/etcd.yaml
+++ b/cfg/cis-1.6-k3s/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate if use etcd as database (Automated)"
-        audit: grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file' 
+        audit: grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'
         tests:
           bin_op: and
           test_items:

--- a/cfg/cis-1.6-k3s/master.yaml
+++ b/cfg/cis-1.6-k3s/master.yaml
@@ -213,7 +213,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --basic-auth-file argument is not set (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "basic-auth-file"
+        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "basic-auth-file" | cat
         tests:
           test_items:
             - flag: "--basic-auth-file"
@@ -224,7 +224,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "token-auth-file"
+        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "token-auth-file" | cat
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -235,7 +235,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "token-auth-file"
+        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "kubelet-https" | cat
         tests:
           bin_op: or
           test_items:
@@ -396,7 +396,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "disable-admission-plugins"
+        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "disable-admission-plugins" | cat
         tests:
           bin_op: or
           test_items:
@@ -542,9 +542,12 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "request-timeout"
+        audit: journalctl -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "request-timeout" | cat
         tests:
+          bin_op: or
           test_items:
+            - flag: "--request-timeout"
+              set: false
             - flag: "--request-timeout"
               compare:
                 op: lte
@@ -719,7 +722,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: journalctl -u k3s | grep "Running kube-controller-manager" | tail -n1 | grep "RotateKubeletServerCertificate"
+        audit: journalctl -u k3s | grep "Running kube-controller-manager" | tail -n1 | grep "RotateKubeletServerCertificate" | cat
         tests:
           bin_op: or
           test_items:


### PR DESCRIPTION
### Linked Issue
fixed https://github.com/aquasecurity/kube-bench/issues/1351

### Changes
This PR attempts to address sortcomings in several of the etcd and master config checks for CIS-1.6-K3s. 
- Most of these fixes revolve around one thing: `grep` returns a nonzero return code when it doesn't find anything. This is a problem for these K3s checks, as the whole point of the check is that the K3s config "is not setting this flag". To sidestep this issue, the grep results are piped to `cat` which does not care if the result is empty. This allows the `set: false` check to work as intended.
- K3s configuration for etcd is largely validated via yaml files, not passed arguments. Thus certain "flags" have different values when described in yaml and the check must be changed to match.

For reference, here is a piece of the K3s etcd config:
```
cat /var/lib/rancher/k3s/server/db/etcd/config
...
client-transport-security:
  cert-file: /var/lib/rancher/k3s/server/tls/etcd/server-client.crt
  client-cert-auth: true
  key-file: /var/lib/rancher/k3s/server/tls/etcd/server-client.key
  trusted-ca-file: /var/lib/rancher/k3s/server/tls/etcd/server-ca.crt
data-dir: /var/lib/rancher/k3s/server/db/etcd
election-timeout: 5000
...
name: server-0-d27e1a2a
peer-transport-security:
  cert-file: /var/lib/rancher/k3s/server/tls/etcd/peer-server-client.crt
  client-cert-auth: true
  key-file: /var/lib/rancher/k3s/server/tls/etcd/peer-server-client.key
  trusted-ca-file: /var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt

```
Checks such as 2.5 cannot blindly look for a `peer-client-cert-auth`, because it is actually contained under the `peer-transport-security` as `client-cert-auth`.

Before PR:
```
== Summary total ==
59 checks PASS
13 checks FAIL
50 checks WARN
0 checks INFO
```

With PR changes:
```
== Summary total ==
71 checks PASS
1 checks FAIL
50 checks WARN
0 checks INFO
```
The 1 failure is actually a failure on my part to hardened a k3s config permissions and is unrelated to this PR.
Signed-off-by: Derek Nola <derek.nola@suse.com>