### PR TITLE
bugfix: false negative when audit_config is defined along with audit …

### DIFF
--- a/check/check_test.go
+++ b/check/check_test.go
@@ -69,6 +69,31 @@ func TestCheck_Run(t *testing.T) {
 			},
 			Expected: PASS,
 		},
+		{
+			name: "Scored checks that pass should PASS when config file is not present",
+			check: Check{
+				Scored:      true,
+				Audit:       "echo hello",
+				AuditConfig: "/test/config.yaml",
+				Tests: &tests{TestItems: []*testItem{{
+					Flag: "hello",
+					Set:  true,
+				}}},
+			},
+			Expected: PASS,
+		},
+		{
+			name: "Scored checks that pass should FAIL when config file is not present",
+			check: Check{
+				Scored:      true,
+				AuditConfig: "/test/config.yaml",
+				Tests: &tests{TestItems: []*testItem{{
+					Flag: "hello",
+					Set:  true,
+				}}},
+			},
+			Expected: FAIL,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
…and config file not found

Suppress the file not found error only when we have audit or auditEnv is defined and they have valid output captured. As, we already have output from audit command. So we can proceed for our tests even though we didnt find config file. 
file not found error: `failed to run: "/test/config.yaml", output: "/bin/sh: line 1: /test/config.yaml: No such file or directory\n", error: exit status 127`

resolve: #1364 
resolve #1242