### PR TITLE
fix: ignore the error from findConfigFile

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -241,7 +241,7 @@ func findConfigFile(candidates []string) string {
 		if err == nil {
 			return c
 		}
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && !strings.HasSuffix(err.Error(), "not a directory") {
 			exitWithError(fmt.Errorf("error looking for file %s: %v", c, err))
 		}
 	}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -233,6 +234,7 @@ func TestFindConfigFile(t *testing.T) {
 		{input: []string{"myfile"}, statResults: []error{nil}, exp: "myfile"},
 		{input: []string{"thisfile", "thatfile"}, statResults: []error{os.ErrNotExist, nil}, exp: "thatfile"},
 		{input: []string{"thisfile", "thatfile"}, statResults: []error{os.ErrNotExist, os.ErrNotExist}, exp: ""},
+		{input: []string{"thisfile", "/etc/dummy/thatfile"}, statResults: []error{os.ErrNotExist, errors.New("stat /etc/dummy/thatfile: not a directory")}, exp: ""},
 	}
 
 	statFunc = fakestat


### PR DESCRIPTION
When we are trying to access a file from a directory which is not present then we get different error. We dont have standard error method to check the msg so added string match for this case
#1439