### PR TITLE
Bump docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 AS build
+FROM golang:1.20.6 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./
@@ -9,7 +9,7 @@ COPY internal/ internal/
 ARG KUBEBENCH_VERSION
 RUN make build && cp kube-bench /go/bin/kube-bench
 
-FROM alpine:3.18 AS run
+FROM alpine:3.18.2 AS run
 WORKDIR /opt/kube-bench/
 # add GNU ps for -C, -o cmd, and --no-headers support
 # https://github.com/aquasecurity/kube-bench/issues/109

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM golang:1.20.4 AS build
+FROM golang:1.20.6 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./


### PR DESCRIPTION
During a recent CVE scan we found kube-bench to use `alpine:3.18` as the final image which has a known high CVE.

```
grype aquasec/kube-bench:v0.6.15
 ✔ Vulnerability DB        [no update available]
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [73 packages]
 ✔ Scanning image...       [4 vulnerabilities]
   ├── 0 critical, 4 high, 0 medium, 0 low, 0 negligible
   └── 4 fixed
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY  SEVERITY
libcrypto3  3.1.0-r4   3.1.1-r0  apk   CVE-2023-2650  High
libssl3     3.1.0-r4   3.1.1-r0  apk   CVE-2023-2650  High
openssl     3.1.0-r4   3.1.1-r0  apk   CVE-2023-2650  High
```

The CVE in question was addressed in the latest [alpine release](https://www.alpinelinux.org/posts/Alpine-3.15.9-3.16.6-3.17.4-3.18.2-released.html), hence updating the dockerfiles accordingly