### PR TITLE
Fix 4.1.7 and 4.1.8 audits: test flag from -z to -n

### DIFF
--- a/cfg/cis-1.7/node.yaml
+++ b/cfg/cis-1.7/node.yaml
@@ -98,8 +98,8 @@ groups:
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+          if test -n "$CAFILE"; then CAFILE=$kubeletcafile; fi
+          if test -e "$CAFILE"; then stat -c permissions=%a "$CAFILE"; fi
         tests:
           test_items:
             - flag: "permissions"
@@ -115,8 +115,8 @@ groups:
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
           CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+          if test -n "$CAFILE"; then CAFILE=$kubeletcafile; fi
+          if test -e "$CAFILE"; then stat -c %U:%G "$CAFILE"; fi
         tests:
           test_items:
             - flag: root:root


### PR DESCRIPTION
# Bug Details

### Fix 4.1.7 and 4.1.8 audits: test flag from -z to -n (+ missing double quotes).

**Target:** node.yaml
**Test ids:** 4.1.7 and 4.1.8
**Impacted CIS versions:** 1.5 to 1.7


1. The `test -z` makes the node.yaml test ids `4.1.7` and `4.1.8` failing, as `-z `verifies if $CAFILE is `zero` instead of `nonzero`, to enter the first if condition and set CAFILE=$kubeletcafile.

As per [test](https://linux.die.net/man/1/test) man page:

```
-n STRING
the length of STRING is nonzero

-z STRING
the length of STRING is zero
```

2. Inclosing #CAFILE with double quotes, so that it is treated as a single string, even if it contains whitespace or special characters.

## Test environment
kube-bench version: `0.6.2`
OS distro: `Ubuntu 18.04.6 LTS`
K8s version: `rke1-v1.25.9`


# Bug Tests

## Before patch

### Failing commands:

```
$ CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
$ echo $CAFILE
/etc/kubernetes/ssl/kube-ca.pem /etc/kubernetes/ssl/kube-ca.pem
$  if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-bash: test: /etc/kubernetes/ssl/kube-ca.pem: binary operator expected
$ if test -z "$CAFILE"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi # Adding double quotes
$ echo $?
0
$ echo $CAFILE
/etc/kubernetes/ssl/kube-ca.pem /etc/kubernetes/ssl/kube-ca.pem # CAFILE should be /etc/kubernetes/ssl/kube-ca.pem, condition failed as it's nonzero string (there is content in it).
```

### Failing logs for 4.1.7 caused by missing double quotes :

```
I0630 17:26:43.069971   29715 check.go:110] -----   Running check 4.1.7   -----
I0630 17:26:43.080767   29715 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -z $CAFILE; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi\n#if test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\n#if test -e \"$CAFILE\"; then stat -c permissions=%a \"$CAFILE\"; fi"
I0630 17:26:43.080791   29715 check.go:300] Output:
 "/bin/sh: 2: test: /etc/kubernetes/ssl/kube-ca.pem: unexpected operator\n/bin/sh: 3: test: /etc/kubernetes/ssl/kube-ca.pem: unexpected operator\n"
I0630 17:26:43.080808   29715 check.go:221] Running 1 test_items
I0630 17:26:43.080817   29715 test.go:151] In flagTestItem.findValue
I0630 17:26:43.080823   29715 test.go:245] Flag 'permissions' does not exist
```


### Failing logs for 4.1.8 caused by missing double quotes:

```
I0630 17:26:43.080872   29715 check.go:110] -----   Running check 4.1.8   -----
I0630 17:26:43.091479   29715 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -z $CAFILE; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e $CAFILE; then stat -c %U:%G $CAFILE; fi\n#if test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\n#if test -e \"$CAFILE\"; then stat -c %U:%G \"$CAFILE\"; fi"
I0630 17:26:43.091503   29715 check.go:300] Output:
 "/bin/sh: 2: test: /etc/kubernetes/ssl/kube-ca.pem: unexpected operator\n/bin/sh: 3: test: /etc/kubernetes/ssl/kube-ca.pem: unexpected operator\n"
I0630 17:26:43.091515   29715 check.go:221] Running 1 test_items
I0630 17:26:43.091523   29715 test.go:151] In flagTestItem.findValue
I0630 17:26:43.091529   29715 test.go:245] Flag 'root:root' does not exist
```

### Failing logs for 4.1.7 with fixed double quotes, but test `-z` present :

```
I0630 17:31:08.022889     944 check.go:110] -----   Running check 4.1.7   -----
I0630 17:31:08.033643     944 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -z \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e \"$CAFILE\"; then stat -c permissions=%a \"$CAFILE\"; fi\n#if test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\n#if test -e \"$CAFILE\"; then stat -c permissions=%a \"$CAFILE\"; fi"
I0630 17:31:08.033700     944 check.go:300] Output:
 ""
I0630 17:31:08.033712     944 check.go:221] Running 1 test_items
I0630 17:31:08.033734     944 test.go:245] Flag 'permissions' does not exist
```


### Failing logs for 4.1.8 with fixed double quotes, but test `-z` present:

```
I0630 17:31:08.033782     944 check.go:110] -----   Running check 4.1.12   -----
I0630 17:31:08.044812     944 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -z \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e \"$CAFILE\"; then stat -c %U:%G \"$CAFILE\"; fi\n#if test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\n#if test -e \"$CAFILE\"; then stat -c %U:%G \"$CAFILE\"; fi"
I0630 17:31:08.044868     944 check.go:300] Output:
 ""
I0630 17:31:08.044887     944 check.go:221] Running 1 test_items
I0630 17:31:08.044901     944 test.go:245] Flag 'root:root' does not exist
```


## After patch (`double quotes + test -n`)

### Successful commands:

```
$ CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
$ echo $CAFILE
/etc/kubernetes/ssl/kube-ca.pem /etc/kubernetes/ssl/kube-ca.pem
$ if test -n "$CAFILE"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi
$ echo $?
0
$ echo $CAFILE
/etc/kubernetes/ssl/kube-ca.pem
```

### Successful logs for 4.1.7:

```
I0630 16:27:42.986053   12490 check.go:110] -----   Running check 4.1.7   -----
I0630 16:27:42.997158   12490 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e \"$CAFILE\"; then stat -c permissions=%a \"$CAFILE\"; fi"
I0630 16:27:42.997187   12490 check.go:300] Output:
 "permissions=600\n"
I0630 16:27:42.997198   12490 check.go:221] Running 1 test_items
I0630 16:27:42.997229   12490 test.go:151] In flagTestItem.findValue 600
I0630 16:27:42.997237   12490 test.go:245] Flag 'permissions' exists
```

### Successful logs for 4.1.8:

```
I0630 16:27:42.997282   12490 check.go:110] -----   Running check 4.1.12   -----
I0630 16:27:43.009269   12490 check.go:299] Command: "CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')\nif test -n \"$CAFILE\"; then CAFILE=/etc/kubernetes/ssl/kube-ca.pem; fi\nif test -e \"$CAFILE\"; then stat -c %U:%G \"$CAFILE\"; fi"
I0630 16:27:43.009302   12490 check.go:300] Output:
 "root:root\n"
I0630 16:27:43.009316   12490 check.go:221] Running 1 test_items
I0630 16:27:43.009385   12490 test.go:151] In flagTestItem.findValue root:root
I0630 16:27:43.009394   12490 test.go:245] Flag 'root:root' exists
```