### PR TITLE
Fix test_items in cis-1.7 - node - 4.2.12

### DIFF
--- a/cfg/cis-1.7/node.yaml
+++ b/cfg/cis-1.7/node.yaml
@@ -424,16 +424,12 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
-          bin_op: or
           test_items:
-            - flag: RotateKubeletServerCertificate
-              path: '{.featureGates.RotateKubeletServerCertificate}'
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
               compare:
-                op: nothave
-                value: false
-            - flag: RotateKubeletServerCertificate
-              path: '{.featureGates.RotateKubeletServerCertificate}'
-              set: false
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
           If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
           TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
### Bug and PR details:

**CIS version**: `cis-1.7`
**Target**: node.yaml
**Test id**:  `4.2.12` 
**Test text**:  Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual). 
**Test modification**: `test_items`
**Reason**: The test_items in cis-1.7 `4.2.12` does not match the test's text and remediation.
**Fix**: Used previous version test_items in `cis-1.24` of `4.2.12` (known as `4.2.13` in `1.24`)

**Related bug issue**: https://github.com/aquasecurity/kube-bench/issues/1468