### PR TITLE
Fix node.yaml - 4.1.7 and 4.1.8 audit by adding uniq

### DIFF
--- a/cfg/ack-1.0/node.yaml
+++ b/cfg/ack-1.0/node.yaml
@@ -97,7 +97,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -114,7 +114,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.20/node.yaml
+++ b/cfg/cis-1.20/node.yaml
@@ -98,7 +98,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -115,7 +115,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.23/node.yaml
+++ b/cfg/cis-1.23/node.yaml
@@ -97,7 +97,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -114,7 +114,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.24/node.yaml
+++ b/cfg/cis-1.24/node.yaml
@@ -97,7 +97,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -114,7 +114,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -106,7 +106,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -124,7 +124,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.6/node.yaml
+++ b/cfg/cis-1.6/node.yaml
@@ -98,7 +98,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -115,7 +115,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:

--- a/cfg/cis-1.7/node.yaml
+++ b/cfg/cis-1.7/node.yaml
@@ -97,7 +97,7 @@ groups:
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
         tests:
@@ -114,7 +114,7 @@ groups:
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
           if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
           if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
         tests:


### PR DESCRIPTION
@mozillazg As discussed in [1467](https://github.com/aquasecurity/kube-bench/pull/1467), I am creating this PR to fix the 4.1.7 and 4.1.8 in node.yaml for the versions `cis-1.5, cis-1.6, cis-1.20, cis-1.23, cis-1.24, cis-1.7, ack-1.0`, by adding `uniq`at the end of the caudit command.

```
cfg git:(node-4.1.7-4.1.8-audit-uniq) ✗ grep -ri -A3  '4.1.7\|4.1.8' . | grep 'apiserver' -B4 | grep 'id\|apiserver' 
./cis-1.20/node.yaml:      - id: 4.1.7
./cis-1.20/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.20/node.yaml:      - id: 4.1.8
./cis-1.20/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.24/node.yaml:      - id: 4.1.7
./cis-1.24/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.24/node.yaml:      - id: 4.1.8
./cis-1.24/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.6/node.yaml:      - id: 4.1.7
./cis-1.6/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.6/node.yaml:      - id: 4.1.8
./cis-1.6/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.23/node.yaml:      - id: 4.1.7
./cis-1.23/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.23/node.yaml:      - id: 4.1.8
./cis-1.23/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.5/node.yaml:      - id: 4.1.7
./cis-1.5/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.5/node.yaml:      - id: 4.1.8
./cis-1.5/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./ack-1.0/node.yaml:      - id: 4.1.7
./ack-1.0/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./ack-1.0/node.yaml:      - id: 4.1.8
./ack-1.0/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.7/node.yaml:      - id: 4.1.7
./cis-1.7/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
./cis-1.7/node.yaml:      - id: 4.1.8
./cis-1.7/node.yaml-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
```
Cheers,
Andy