### PR TITLE
chore: add fips compliant images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,3 +83,22 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/release
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Build and push fips ubi image - Docker/ECR
+        id: docker_build_fips_ubi
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          file: Dockerfile.fips.ubi
+          build-args: |
+            KUBEBENCH_VERSION=${{ steps.get_version.outputs.version }}
+          tags: |
+            ${{ env.DOCKERHUB_ALIAS }}/${{ env.REP }}:${{ steps.get_version.outputs.version }}-ubi-fips
+            public.ecr.aws/${{ env.ALIAS }}/${{ env.REP }}:${{ steps.get_version.outputs.version }}-ubi-fips
+          cache-from: type=local,src=/tmp/.buildx-cache/release
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/release
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -1,0 +1,49 @@
+FROM golang:1.20.4 AS build
+WORKDIR /go/src/github.com/aquasecurity/kube-bench/
+COPY makefile makefile
+COPY go.mod go.sum ./
+COPY main.go .
+COPY check/ check/
+COPY cmd/ cmd/
+COPY internal/ internal/
+ARG KUBEBENCH_VERSION
+RUN make build-fips && cp kube-bench /go/bin/kube-bench
+
+
+# ubi8-minimal base image for build with ubi standards
+FROM registry.access.redhat.com/ubi8/ubi-minimal as run
+
+RUN microdnf install -y yum findutils openssl \
+  && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
+  && yum update -y \
+  && yum install -y glibc \
+  && yum update -y glibc \
+  && yum install -y procps \
+  && yum update -y procps \
+  && yum install jq -y \
+  && yum clean all \
+  && microdnf remove yum || rpm -e -v yum \
+  && microdnf clean all
+
+WORKDIR /opt/kube-bench/
+
+ENV PATH=$PATH:/usr/local/mount-from-host/bin 
+
+COPY LICENSE /licenses/LICENSE
+COPY --from=build /go/bin/kube-bench /usr/local/bin/kube-bench
+COPY entrypoint.sh .
+COPY cfg/ cfg/
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["install"]
+
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.name="kube-bench" \
+    org.label-schema.description="Run the CIS Kubernetes Benchmark tests" \
+    org.label-schema.url="https://github.com/aquasecurity/kube-bench" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/aquasecurity/kube-bench" \
+    org.label-schema.schema-version="1.0"

--- a/fipsonly.go
+++ b/fipsonly.go
@@ -1,0 +1,7 @@
+//go:build fipsonly
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/makefile
+++ b/makefile
@@ -39,6 +39,9 @@ build: $(BINARY)
 $(BINARY): $(SOURCES)
 	GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=$(KUBEBENCH_VERSION)" -o $(BINARY) .
 
+build-fips:
+	GOOS=$(GOOS) CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -tags fipsonly -ldflags "-X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=$(KUBEBENCH_VERSION)" -o $(BINARY) .
+
 # builds the current dev docker version
 build-docker:
 	docker build --build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \


### PR DESCRIPTION
For fips complaince we need to generate fips compliant images. As part of this change, we will create new kube-bench image which will be fips compliant. Image name follows this tag pattern <version>-ubi-fips