### PR TITLE
[job.yaml] fix a typo in image tag .

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - command: ["kube-bench"]
-          image: docker.io/aquasec/kube-bench:vv0.6.16-rc
+          image: docker.io/aquasec/kube-bench:v0.6.16-rc
           name: kube-bench
           volumeMounts:
             - mountPath: /var/lib/etcd


### PR DESCRIPTION
docker.io/aquasec/kube-bench:vv0.6.16-rc -> docker.io/aquasec/kube-bench:v0.6.16-rc