### PR TITLE
Added empty actual value and expected value and non-empty flagName test

### DIFF
--- a/check/test.go
+++ b/check/test.go
@@ -143,7 +143,11 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 				if strings.HasPrefix(t.Flag, "--") {
 					value = "true"
 				} else {
-					value = ""
+					if t.Compare.Op == "eq" {
+						value = ""
+					} else {
+						value = vals[1]
+					}
 				}
 			}
 		} else {

--- a/check/test.go
+++ b/check/test.go
@@ -143,7 +143,7 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 				if strings.HasPrefix(t.Flag, "--") {
 					value = "true"
 				} else {
-					if t.Compare.Op == "eq" {
+					if t.Compare.Op == "eq" && !strings.Contains(t.Flag, ":") {
 						value = ""
 					} else {
 						value = vals[1]

--- a/check/test.go
+++ b/check/test.go
@@ -143,7 +143,7 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 				if strings.HasPrefix(t.Flag, "--") {
 					value = "true"
 				} else {
-					value = vals[1]
+					value = ""
 				}
 			}
 		} else {

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -600,6 +600,7 @@ func TestCompareOp(t *testing.T) {
 
 		// Test Op "eq"
 		{label: "op=eq, both empty", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'' is equal to ''", testResult: true, flagName: ""},
+		{label: "op=eq, both empty, flagName non empty", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'' is equal to ''", testResult: true, flagName: "flagName"},
 
 		{
 			label: "op=eq, true==true", op: "eq", flagVal: "true",

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -600,7 +600,7 @@ func TestCompareOp(t *testing.T) {
 
 		// Test Op "eq"
 		{label: "op=eq, both empty", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'' is equal to ''", testResult: true, flagName: ""},
-		{label: "op=eq, both empty, flagName non empty", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'' is equal to ''", testResult: true, flagName: "flagName"},
+		{label: "op=eq, both empty, flagName non empty", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'flagName' is equal to ''", testResult: true, flagName: "flagName"},
 
 		{
 			label: "op=eq, true==true", op: "eq", flagVal: "true",


### PR DESCRIPTION
- Close #1515

Kube-bench checks fail when the `flagVal` and `compareValue` are empty strings and `flagName` is given. To resolve this, I have updated the code where `flagName` is assigned to the `compareVal` and added a test for the same.



**Expected Outcome**
```Js
{label: “empty - val”, op: “eq”, flagVal: “”, compareValue: “”, expectedResultPattern: “‘flagName’ is equal to ‘’“, testResult: true, flagName: “flagName”}
```

**Actual Outcome**
```Js
{label: "empty - val", op: "eq", flagVal: "", compareValue: "", expectedResultPattern: "'flagName' is equal to ''", testResult: false, flagName: "flagName"}
```
