### PR TITLE
 The Kubernetes CIS reports indicate that N/A is recorded as a failure for 4.1.2 (node.yaml)

### DIFF
--- a/cfg/ack-1.0/node.yaml
+++ b/cfg/ack-1.0/node.yaml
@@ -25,14 +25,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.20/node.yaml
+++ b/cfg/cis-1.20/node.yaml
@@ -25,14 +25,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.23/node.yaml
+++ b/cfg/cis-1.23/node.yaml
@@ -24,14 +24,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.24/node.yaml
+++ b/cfg/cis-1.24/node.yaml
@@ -24,14 +24,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.5/node.yaml
+++ b/cfg/cis-1.5/node.yaml
@@ -25,16 +25,17 @@ groups:
         scored: true
 
       - id: 4.1.2
-        text: "Ensure that the kubelet service file ownership is set to root:root (Scored)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
-              set: true
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.6/node.yaml
+++ b/cfg/cis-1.6/node.yaml
@@ -25,10 +25,12 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,

--- a/cfg/cis-1.7/node.yaml
+++ b/cfg/cis-1.7/node.yaml
@@ -24,14 +24,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3

--- a/cfg/cis-1.8/node.yaml
+++ b/cfg/cis-1.8/node.yaml
@@ -24,14 +24,16 @@ groups:
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        audit: '/bin/sh -c "if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
+            - flag: "File not found"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+            Run the below command (based on the file location on your system) on the each worker node.
+            For example,
+            chown root:root $kubeletsvc
         scored: true
 
       - id: 4.1.3


### PR DESCRIPTION
Issue: The initial command produces "root:root" as its output only when the file is present. However, if the file is missing, the command will still run successfully, though the desired output of "root:root" won't be obtained.

Fix: To address this, we've modified the command to achieve the following:

Verify the existence of the file.

If the file is found, show the user and group ownership in the "username:groupname" format.

If the file is not found, display the message "File not found."

To accommodate this change, we've integrated the expected output "File not found" for instances where the file is absent. This adjustment ensures the successful execution of the test.