### PR TITLE
Rancher node checks correction

### DIFF
--- a/cfg/k3s-cis-1.23/node.yaml
+++ b/cfg/k3s-cis-1.23/node.yaml
@@ -149,9 +149,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/k3s-cis-1.24/node.yaml
+++ b/cfg/k3s-cis-1.24/node.yaml
@@ -118,9 +118,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/k3s-cis-1.7/node.yaml
+++ b/cfg/k3s-cis-1.7/node.yaml
@@ -114,9 +114,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke-cis-1.23/node.yaml
+++ b/cfg/rke-cis-1.23/node.yaml
@@ -111,9 +111,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke-cis-1.24/node.yaml
+++ b/cfg/rke-cis-1.24/node.yaml
@@ -94,27 +94,27 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
+        audit: '/bin/sh -c "if test -e /node/etc/kubernetes/ssl/kube-ca.pem; then stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "600"
+            - flag: "File not found"
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
         scored: true
-
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
+        audit: '/bin/sh -c "if test -e /node/etc/kubernetes/ssl/kube-ca.pem; then stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem; else echo \"File not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
+            - flag: "File not found"
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke-cis-1.7/node.yaml
+++ b/cfg/rke-cis-1.7/node.yaml
@@ -116,9 +116,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke2-cis-1.23/node.yaml
+++ b/cfg/rke2-cis-1.23/node.yaml
@@ -119,9 +119,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke2-cis-1.24/node.yaml
+++ b/cfg/rke2-cis-1.24/node.yaml
@@ -119,9 +119,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>

--- a/cfg/rke2-cis-1.7/node.yaml
+++ b/cfg/rke2-cis-1.7/node.yaml
@@ -120,9 +120,6 @@ groups:
         tests:
           test_items:
             - flag: root:root
-              compare:
-                op: eq
-                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>


### PR DESCRIPTION
1. Have modified test criteria such that it produces right output in case of there is no file exists.
2. Have modified the tests wherever root:root is checked both in flag and value.