### PR TITLE
Replace custom k3s etcd script checks with vanilla grep checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: latest
+          version: v1.57.2
           args: --verbose
   unit:
     name: Unit tests

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -95,6 +95,7 @@ master:
     datadirs:
       - /var/lib/etcd/default.etcd
       - /var/lib/etcd/data.etcd
+      - /var/lib/rancher/k3s/server/db/etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.yml
@@ -105,6 +106,7 @@ master:
       - /var/snap/microk8s/current/args/etcd
       - /usr/lib/systemd/system/etcd.service
       - /var/lib/rancher/rke2/server/db/etcd/config
+      - /var/lib/rancher/k3s/server/db/etcd/config
     defaultconf: /etc/kubernetes/manifests/etcd.yaml
     defaultdatadir: /var/lib/etcd/default.etcd
 
@@ -234,6 +236,7 @@ etcd:
     datadirs:
       - /var/lib/etcd/default.etcd
       - /var/lib/etcd/data.etcd
+      - /var/lib/rancher/k3s/server/db/etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.yml

--- a/cfg/k3s-cis-1.23/config.yaml
+++ b/cfg/k3s-cis-1.23/config.yaml
@@ -24,7 +24,8 @@ master:
   etcd:
     bins:
       - containerd
-
+    datadirs:
+      - /var/lib/rancher/k3s/server/db/etcd
   node:
     components:
       - kubelet

--- a/cfg/k3s-cis-1.23/etcd.yaml
+++ b/cfg/k3s-cis-1.23/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.1"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -30,7 +30,7 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.2"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -50,7 +50,7 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.3"
+        audit: "grep 'auto-tls' $etcdconf"
         tests:
           bin_op: or
           test_items:
@@ -70,7 +70,7 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.4"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -91,7 +91,7 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.5"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -111,7 +111,7 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.6"
+        audit: "grep 'peer-auto-tls' $etcdconf"
         tests:
           bin_op: or
           test_items:
@@ -132,7 +132,7 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
-        audit: "check_for_k3s_etcd.sh 2.7"
+        audit: "grep 'trusted-ca-file' $etcdconf"
         tests:
           test_items:
             - flag: "trusted-ca-file"

--- a/cfg/k3s-cis-1.23/etcd.yaml
+++ b/cfg/k3s-cis-1.23/etcd.yaml
@@ -10,15 +10,13 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
@@ -30,14 +28,13 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -50,15 +47,13 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "grep 'auto-tls' $etcdconf"
+        audit: "if grep -q '^auto-tls' $etcdconf;then grep '^auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               set: false
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -70,15 +65,13 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_PEER_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_PEER_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
@@ -91,14 +84,13 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -111,15 +103,13 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "grep 'peer-auto-tls' $etcdconf"
+        audit: "if grep -q '^peer-auto-tls' $etcdconf;then grep '^peer-auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               set: false
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -132,11 +122,10 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
-        audit: "grep 'trusted-ca-file' $etcdconf"
+        audit: "if grep -q 'trusted-ca-file' $etcdconf;then grep 'trusted-ca-file' $etcdconf;else echo 'notset';fi"
         tests:
           test_items:
             - flag: "trusted-ca-file"
-              env: "ETCD_TRUSTED_CA_FILE"
               set: true
         remediation: |
           [Manual test]

--- a/cfg/k3s-cis-1.23/master.yaml
+++ b/cfg/k3s-cis-1.23/master.yaml
@@ -155,7 +155,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
         tests:
           test_items:
             - flag: "700"
@@ -736,7 +736,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: "journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver'"
         tests:
           bin_op: and
           test_items:

--- a/cfg/k3s-cis-1.23/master.yaml
+++ b/cfg/k3s-cis-1.23/master.yaml
@@ -155,7 +155,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
+        audit: "stat -c %a $etcddatadir"
         tests:
           test_items:
             - flag: "700"

--- a/cfg/k3s-cis-1.24/config.yaml
+++ b/cfg/k3s-cis-1.24/config.yaml
@@ -24,6 +24,8 @@ master:
   etcd:
     bins:
       - containerd
+    datadirs:
+      - /var/lib/rancher/k3s/server/db/etcd
 
   node:
     components:

--- a/cfg/k3s-cis-1.24/etcd.yaml
+++ b/cfg/k3s-cis-1.24/etcd.yaml
@@ -10,15 +10,13 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
@@ -30,14 +28,13 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -50,15 +47,13 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "grep 'auto-tls' $etcdconf"
+        audit: "if grep -q '^auto-tls' $etcdconf;then grep '^auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               set: false
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -70,15 +65,13 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_PEER_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_PEER_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
@@ -91,14 +84,13 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -111,15 +103,13 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "grep 'peer-auto-tls' $etcdconf"
+        audit: "if grep -q '^peer-auto-tls' $etcdconf;then grep '^peer-auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               set: false
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -132,11 +122,10 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "grep 'trusted-ca-file' $etcdconf"
+        audit: "if grep -q 'trusted-ca-file' $etcdconf;then grep 'trusted-ca-file' $etcdconf;else echo 'notset';fi"
         tests:
           test_items:
             - flag: "trusted-ca-file"
-              env: "ETCD_TRUSTED_CA_FILE"
               set: true
         remediation: |
           [Manual test]

--- a/cfg/k3s-cis-1.24/etcd.yaml
+++ b/cfg/k3s-cis-1.24/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.1"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -30,7 +30,7 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.2"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -50,7 +50,7 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.3"
+        audit: "grep 'auto-tls' $etcdconf"
         tests:
           bin_op: or
           test_items:
@@ -70,7 +70,7 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.4"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -91,7 +91,7 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.5"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -111,7 +111,7 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.6"
+        audit: "grep 'peer-auto-tls' $etcdconf"
         tests:
           bin_op: or
           test_items:
@@ -132,7 +132,7 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.7"
+        audit: "grep 'trusted-ca-file' $etcdconf"
         tests:
           test_items:
             - flag: "trusted-ca-file"

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -155,7 +155,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
         tests:
           test_items:
             - flag: "700"
@@ -735,7 +735,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: "journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver'"
         tests:
           bin_op: and
           test_items:

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -155,7 +155,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
+        audit: "stat -c %a $etcddatadir"
         tests:
           test_items:
             - flag: "700"

--- a/cfg/k3s-cis-1.7/config.yaml
+++ b/cfg/k3s-cis-1.7/config.yaml
@@ -31,7 +31,8 @@ master:
   etcd:
     bins:
       - containerd
-
+    datadirs:
+      - /var/lib/rancher/k3s/server/db/etcd
   node:
     components:
       - kubelet

--- a/cfg/k3s-cis-1.7/etcd.yaml
+++ b/cfg/k3s-cis-1.7/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.1"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -30,7 +30,7 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.2"
+        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -50,7 +50,7 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.3"
+        audit: "grep 'auto-tls' $etcdconf | true"
         tests:
           bin_op: or
           test_items:
@@ -70,7 +70,7 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.4"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
@@ -91,7 +91,7 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.5"
+        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
@@ -111,7 +111,7 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.6"
+        audit: "grep 'peer-auto-tls' $etcdconf | true"
         tests:
           bin_op: or
           test_items:
@@ -132,7 +132,7 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "check_for_k3s_etcd.sh 2.7"
+        audit: "grep 'trusted-ca-file' $etcdconf"
         tests:
           test_items:
             - flag: "trusted-ca-file"

--- a/cfg/k3s-cis-1.7/etcd.yaml
+++ b/cfg/k3s-cis-1.7/etcd.yaml
@@ -10,15 +10,13 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
@@ -30,14 +28,13 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -50,15 +47,13 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "grep 'auto-tls' $etcdconf | true"
+        audit: "if grep -q '^auto-tls' $etcdconf;then grep '^auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               set: false
             - flag: "--auto-tls"
-              env: "ETCD_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -70,15 +65,13 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
         tests:
           bin_op: and
           test_items:
             - flag: "cert-file"
-              env: "ETCD_PEER_CERT_FILE"
               set: true
             - flag: "key-file"
-              env: "ETCD_PEER_KEY_FILE"
               set: true
         remediation: |
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
@@ -91,14 +84,13 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 5 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
         tests:
           bin_op: or
           test_items:
             - flag: "--client-cert-auth"
               set: true
             - flag: "client-cert-auth"
-              env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
@@ -111,15 +103,13 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "grep 'peer-auto-tls' $etcdconf | true"
+        audit: "if grep -q '^peer-auto-tls' $etcdconf;then grep '^peer-auto-tls' $etcdconf;else echo 'notset';fi"
         tests:
           bin_op: or
           test_items:
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               set: false
             - flag: "--peer-auto-tls"
-              env: "ETCD_PEER_AUTO_TLS"
               compare:
                 op: eq
                 value: false
@@ -132,11 +122,10 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "grep 'trusted-ca-file' $etcdconf"
+        audit: "if grep -q 'trusted-ca-file' $etcdconf;then grep 'trusted-ca-file' $etcdconf;else echo 'notset';fi"
         tests:
           test_items:
             - flag: "trusted-ca-file"
-              env: "ETCD_TRUSTED_CA_FILE"
               set: true
         remediation: |
           [Manual test]

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -167,7 +167,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
         tests:
           test_items:
             - flag: "700"
@@ -738,7 +738,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: and
           test_items:

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -167,7 +167,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
+        audit: "stat -c %a $etcddatadir"
         tests:
           test_items:
             - flag: "700"


### PR DESCRIPTION
Background:
When https://github.com/aquasecurity/kube-bench/pull/1523 was merged, it pulled the cfg checks directly from https://github.com/rancher/security-scan/tree/master/package/cfg.

Problem:
- These checks utilizes a custom sonobuoy plugin to deploy kube-bench + [additional helper scripts](https://github.com/rancher/security-scan/tree/master/package/helper_scripts). These additional helper scripts were not accounted for when copying over the cfg. K3s utilizes kine which allows sqlite and other non etcd databases. The helper scripts allowed CIS check to pass on these other DB. These helper scripts do not exist in upstream kubebench.

Solution:
- This PR fixes the k3s 1.23, 1.24, and 1.7 benchmarks, restoring the correct etcd checks

Note: This means that running these benchmarks will only pass these checks is K3s is utilizing etcd (via the `--cluster-init` embedded etcd flag). It does not solve the original problem the custom scripts rancher implemented do. 


Validation:
- k3s version v1.29.4+k3s1, with hardening applied using https://docs.k3s.io/security/hardening-guide

main:
```
== Summary total ==
42 checks PASS
8 checks FAIL
45 checks WARN
36 checks INFO
```

this PR:
```
== Summary total ==
51 checks PASS
0 checks FAIL
44 checks WARN
36 checks INFO
```