### PR TITLE
Overhaul of K3s scans

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -164,7 +164,6 @@ node:
       - "/var/snap/microk8s/current/credentials/kubelet.config"
       - "/etc/kubernetes/kubeconfig-kubelet"
       - "/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
-      - "/var/lib/rancher/k3s/server/cred/admin.kubeconfig"
       - "/var/lib/rancher/k3s/agent/kubelet.kubeconfig"
     confs:
       - "/etc/kubernetes/kubelet-config.yaml"
@@ -190,7 +189,6 @@ node:
       - "/etc/systemd/system/snap.kubelet.daemon.service"
       - "/etc/systemd/system/snap.microk8s.daemon-kubelet.service"
       - "/etc/kubernetes/kubelet.yaml"
-      - "/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
 
     defaultconf: "/var/lib/kubelet/config.yaml"
     defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -436,6 +436,12 @@ target_mapping:
     - "controlplane"
     - "node"
     - "policies"
+  "k3s-cis-1.8":
+    - "master"
+    - "etcd"
+    - "controlplane"
+    - "node"
+    - "policies"
   "k3s-cis-1.23":
     - "master"
     - "etcd"

--- a/cfg/k3s-cis-1.23/controlplane.yaml
+++ b/cfg/k3s-cis-1.23/controlplane.yaml
@@ -21,7 +21,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         type: "manual"
         tests:
           test_items:

--- a/cfg/k3s-cis-1.23/master.yaml
+++ b/cfg/k3s-cis-1.23/master.yaml
@@ -323,7 +323,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         type: manual
         tests:
           test_items:
@@ -371,7 +371,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
         type: "skip"
         tests:
           bin_op: or
@@ -389,7 +389,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -406,7 +406,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -420,7 +420,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -436,7 +436,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -451,7 +451,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -466,7 +466,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -483,7 +483,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -517,7 +517,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -538,7 +538,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -557,7 +557,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -575,7 +575,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -592,7 +592,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -610,7 +610,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -625,7 +625,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -639,7 +639,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -656,7 +656,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -673,7 +673,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -689,7 +689,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -702,7 +702,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -722,7 +722,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"
         tests:
           test_items:
@@ -736,7 +736,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver'"
+        audit: "journalctl -m -u k3s | grep -m1 'Running kube-apiserver'"
         tests:
           bin_op: and
           test_items:
@@ -754,7 +754,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
+        audit: "journalctl -m -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
         tests:
           bin_op: and
           test_items:
@@ -772,7 +772,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -785,7 +785,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -798,7 +798,7 @@ groups:
 
       - id: 1.2.30
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -820,7 +820,7 @@ groups:
 
       - id: 1.2.32
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -845,7 +845,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -857,7 +857,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -872,7 +872,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -887,7 +887,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -900,7 +900,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -912,7 +912,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
         type: "skip"
         tests:
           bin_op: or
@@ -953,7 +953,7 @@ groups:
     checks:
       - id: 1.4.1
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1"
         tests:
           test_items:
             - flag: "--profiling"
@@ -969,7 +969,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/cfg/k3s-cis-1.23/node.yaml
+++ b/cfg/k3s-cis-1.23/node.yaml
@@ -186,7 +186,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -209,7 +209,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -231,7 +231,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
@@ -251,7 +251,7 @@ groups:
 
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -m -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         tests:
           bin_op: or
           test_items:
@@ -276,7 +276,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -m -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -302,7 +302,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -m -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
         type: "skip"
         tests:
           test_items:
@@ -325,7 +325,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -m -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         type: "skip"
         tests:
           test_items:
@@ -393,7 +393,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/cfg/k3s-cis-1.24/config.yaml
+++ b/cfg/k3s-cis-1.24/config.yaml
@@ -16,33 +16,43 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
+
 
   etcd:
     bins:
       - containerd
-    datadirs:
-      - /var/lib/rancher/k3s/server/db/etcd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+etcd:
+  components:
+    - etcd
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  etcd:
+    confs: /var/lib/rancher/k3s/server/db/etcd/config
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+node:
+  components:
+    - kubelet
+    - proxy
 
-  policies:
-    components:
-      - policies
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+
+policies:
+  components:
+    - policies

--- a/cfg/k3s-cis-1.24/controlplane.yaml
+++ b/cfg/k3s-cis-1.24/controlplane.yaml
@@ -21,7 +21,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/cfg/k3s-cis-1.24/etcd.yaml
+++ b/cfg/k3s-cis-1.24/etcd.yaml
@@ -10,128 +10,135 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: and
           test_items:
-            - flag: "cert-file"
-              set: true
-            - flag: "key-file"
-              set: true
+            - path: "{.client-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
+            - path: "{.client-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
         remediation: |
-          Follow the etcd service documentation and configure TLS encryption.
-          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
-          on the master node and set the below parameters.
-          --cert-file=</path/to/ca-file>
-          --key-file=</path/to/key-file>
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom cert and key files.
+        scored: false
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit_config: "cat $etcdconf"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--client-cert-auth"
-              set: true
-            - flag: "client-cert-auth"
+            - path: "{.client-transport-security.client-cert-auth}"
               compare:
                 op: eq
                 value: true
-              set: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
-          node and set the below parameter.
-          --client-cert-auth="true"
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --client-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable client certificate authentication.
+        scored: false
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "if grep -q '^auto-tls' $etcdconf;then grep '^auto-tls' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: or
           test_items:
-            - flag: "--auto-tls"
-              set: false
-            - flag: "--auto-tls"
+            - path: "{.client-transport-security.auto-tls}"
               compare:
                 op: eq
                 value: false
+            - path: "{.client-transport-security.auto-tls}"
+              set: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
           node and either remove the --auto-tls parameter or set it to false.
-            --auto-tls=false
-        scored: true
+          client-transport-security:
+            auto-tls: false
+        scored: false
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: and
           test_items:
-            - flag: "cert-file"
-              set: true
-            - flag: "key-file"
-              set: true
+            - path: "{.peer-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.crt"
+            - path: "{.peer-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.key"
         remediation: |
-          Follow the etcd service documentation and configure peer TLS encryption as appropriate
-          for your etcd cluster.
-          Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameters.
-          --peer-client-file=</path/to/peer-cert-file>
-          --peer-key-file=</path/to/peer-key-file>
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates peer cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom peer cert and key files.
+        scored: false
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit_config: "cat $etcdconf"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--client-cert-auth"
-              set: true
-            - flag: "client-cert-auth"
+            - path: "{.peer-transport-security.client-cert-auth}"
               compare:
                 op: eq
                 value: true
-              set: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
-          node and set the below parameter.
-          --peer-client-cert-auth=true
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --peer-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable peer client certificate authentication.
+        scored: false
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "if grep -q '^peer-auto-tls' $etcdconf;then grep '^peer-auto-tls' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: or
           test_items:
-            - flag: "--peer-auto-tls"
-              set: false
-            - flag: "--peer-auto-tls"
+            - path: "{.peer-transport-security.auto-tls}"
               compare:
                 op: eq
                 value: false
-              set: true
+            - path: "{.peer-transport-security.auto-tls}"
+              set: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --peer-auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
           node and either remove the --peer-auto-tls parameter or set it to false.
-          --peer-auto-tls=false
-        scored: true
+          peer-transport-security:
+            auto-tls: false
+        scored: false
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "if grep -q 'trusted-ca-file' $etcdconf;then grep 'trusted-ca-file' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           test_items:
-            - flag: "trusted-ca-file"
-              set: true
+            - path: "{.peer-transport-security.trusted-ca-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt"
         remediation: |
-          [Manual test]
-          Follow the etcd documentation and create a dedicated certificate authority setup for the
-          etcd service.
-          Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameter.
-          --trusted-ca-file=</path/to/ca-file>
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates a unique certificate authority for etcd.
+          This is located at /var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use a shared certificate authority.
         scored: false

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -19,9 +19,8 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 644 $apiserverconf
+          Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,8 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
+          Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,8 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
+          Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,8 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
+          Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,8 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
+          Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,8 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
+          Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -101,9 +100,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
+          Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -114,17 +112,14 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
+          Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -133,12 +128,12 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          Not Applicable.
+          The default K3s CNI, flannel, does not create any files in /var/lib/cni/networks.
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: "skip"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
@@ -148,21 +143,24 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root <path/to/cni/files>
+          Not Applicable.
+          The default K3s CNI, flannel, does not create any files in /var/lib/cni/networks.
         scored: false
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a $etcddatadir"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -178,15 +176,14 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
+          Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:
@@ -212,12 +209,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -232,7 +229,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -244,7 +241,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -287,8 +284,8 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -297,14 +294,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -313,9 +310,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2
@@ -323,7 +320,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -331,27 +328,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "token-auth-file=<path>"
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -359,18 +358,18 @@ groups:
               compare:
                 op: nothave
                 value: "DenyServiceExternalIPs"
-              set: true
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           bin_op: or
@@ -388,24 +387,25 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+            - "kubelet-client-certificate=<path/to/client-cert-file>"
+            - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.6
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -419,7 +419,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -427,15 +427,15 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -443,14 +443,14 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -458,14 +458,14 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.10
-        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -474,15 +474,15 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,EventRateLimit,..."
+            - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -493,14 +493,15 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.12
-        text: "Ensure that the admission control plugin AlwaysPullImages is set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -508,15 +509,18 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.13
-        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -537,7 +541,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
         tests:
           bin_op: or
           test_items:
@@ -548,15 +552,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -567,14 +572,15 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.16
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -582,16 +588,16 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.17
         text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -602,14 +608,15 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.18
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -617,29 +624,28 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
+          kube-apiserver-arg:
+            - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -647,16 +653,15 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+            - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -664,16 +669,15 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -681,27 +685,33 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.23
-        text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
         tests:
+          bin_op: or
           test_items:
             - flag: "--request-timeout"
+              set: false
+            - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-        scored: true
+          Permissive, per CIS guidelines,
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+            - "request-timeout=300s"
+        scored: false
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -712,30 +722,36 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+            - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver'"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:
@@ -744,11 +760,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-certfile=<path>"
+            - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.27
@@ -762,57 +779,61 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "tls-cert-file=<path>"
+            - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.28
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.29
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.30
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.31
-        text: "Ensure that encryption providers are appropriately configured (Automated)"
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -820,13 +841,16 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
       - id: 1.2.32
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -834,36 +858,32 @@ groups:
                 op: valid_elements
                 value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
         remediation: |
-          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
-          on the control plane node and set the below parameter.
-          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,
-          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
-          TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
-        scored: false
+          By default, the K3s kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments.
+          If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements.
+          If this check fails, remove any custom configuration around `tls-cipher-suites` or update the /etc/rancher/k3s/config.yaml file to match the default by adding the following:
+          kube-apiserver-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+        scored: true
 
   - id: 1.3
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+            - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -871,14 +891,15 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -886,40 +907,43 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -931,14 +955,16 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+            - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:
@@ -950,8 +976,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -968,14 +996,15 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:
@@ -987,6 +1016,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "bind-address=<IP>"
         scored: true

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -148,7 +148,7 @@ groups:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
           else
             echo "permissions=700"
@@ -318,7 +318,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -334,7 +334,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -348,7 +348,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -367,7 +367,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           bin_op: or
@@ -385,7 +385,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -403,7 +403,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -417,7 +417,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -433,7 +433,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -448,7 +448,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -463,7 +463,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -480,7 +480,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -499,7 +499,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -518,7 +518,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -539,7 +539,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
         tests:
           bin_op: or
           test_items:
@@ -559,7 +559,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -578,7 +578,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -595,7 +595,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -614,7 +614,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -630,7 +630,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -643,7 +643,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -659,7 +659,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -675,7 +675,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -691,7 +691,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
         tests:
           bin_op: or
           test_items:
@@ -709,7 +709,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -730,7 +730,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -745,8 +745,8 @@ groups:
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -m -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
           else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
@@ -768,7 +768,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
+        audit: "journalctl -m -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
         tests:
           bin_op: and
           test_items:
@@ -787,7 +787,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -801,7 +801,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -815,7 +815,7 @@ groups:
 
       - id: 1.2.30
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -830,7 +830,7 @@ groups:
       - id: 1.2.31
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
@@ -848,7 +848,7 @@ groups:
 
       - id: 1.2.32
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -868,7 +868,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -881,7 +881,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -897,7 +897,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -913,7 +913,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -927,7 +927,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -941,7 +941,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -962,7 +962,7 @@ groups:
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:
@@ -985,7 +985,7 @@ groups:
     checks:
       - id: 1.4.1
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1"
         tests:
           test_items:
             - flag: "--profiling"
@@ -1002,7 +1002,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -311,7 +311,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -330,7 +330,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -639,10 +639,10 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
         tests:
           test_items:
@@ -655,10 +655,10 @@ groups:
           set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=30"
-        scored: true
+        scored: false
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
         tests:
           test_items:
@@ -671,10 +671,10 @@ groups:
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=10"
-        scored: true
+        scored: false
 
       - id: 1.2.22
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
         tests:
           test_items:
@@ -687,7 +687,7 @@ groups:
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=100"
-        scored: true
+        scored: false
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"

--- a/cfg/k3s-cis-1.24/master.yaml
+++ b/cfg/k3s-cis-1.24/master.yaml
@@ -133,11 +133,9 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G\
         type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
           test_items:
@@ -145,7 +143,7 @@ groups:
         remediation: |
           Not Applicable.
           The default K3s CNI, flannel, does not create any files in /var/lib/cni/networks.
-        scored: false
+        scored: true
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"

--- a/cfg/k3s-cis-1.24/node.yaml
+++ b/cfg/k3s-cis-1.24/node.yaml
@@ -317,7 +317,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/cfg/k3s-cis-1.24/node.yaml
+++ b/cfg/k3s-cis-1.24/node.yaml
@@ -19,8 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example, chmod 600 $kubeletsvc
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.2
@@ -31,14 +31,13 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -51,11 +50,11 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chmod 600 $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
-        audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
+        audit: 'stat -c %U:%G $proxykubeconfig'
         tests:
           bin_op: or
           test_items:
@@ -63,18 +62,17 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubelet.kubeconfig '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
-            - flag: "600"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "600"
-              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -83,7 +81,7 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
+        audit: 'stat -c %U:%G $kubeletkubeconfig'
         tests:
           test_items:
             - flag: "root:root"
@@ -98,8 +96,8 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"
@@ -109,22 +107,25 @@ groups:
               set: true
         remediation: |
           Run the following command to modify the file permissions of the
-          --client-ca-file chmod 600 <filename>
-        scored: false
+          --client-ca-file chmod 600 $kubeletcafile
+        scored: true
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root
+              compare:
+                op: eq
+                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
-          chown root:root <filename>
-        scored: false
+          chown root:root $kubeletcafile
+        scored: true
 
       - id: 4.1.9
-        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Manual)"
+        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
         type: "skip"
         tests:
@@ -134,20 +135,20 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chmod 600 $kubeletconf
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.10
-        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
         type: "skip"
         tests:
           test_items:
             - flag: root:root
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chown root:root $kubeletconf
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
         scored: true
 
   - id: 4.2
@@ -165,20 +166,20 @@ groups:
                 value: false
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -188,39 +189,33 @@ groups:
                 value: AlwaysAllow
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/agent/client-ca.crt
         scored: true
 
       - id: 4.2.4
-        text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        text: "Verify that the --read-only-port argument is set to 0 (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -233,19 +228,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
-        scored: false
+          systemctl restart k3s.service
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -258,21 +254,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
-        type: "skip"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -282,20 +274,16 @@ groups:
                 value: true
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `protectKernelDefaults` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --protect-kernel-defaults=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          protect-kernel-defaults: true
+          If using the command line, run K3s with --protect-kernel-defaults=true.
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
-        type: "skip"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -309,39 +297,31 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kubelet-arg:
+            - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.8
-        text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
-        audit: "/bin/ps -fC $kubeletbin "
+        text: "Ensure that the --hostname-override argument is not set (Automated)"
         type: "skip"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -351,18 +331,18 @@ groups:
                 op: eq
                 value: 0
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "event-qps=<value>"
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.10
-        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -370,23 +350,19 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-        scored: false
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+            - "tls-cert-file=<path/to/tls-cert-file>"
+            - "tls-private-key-file=<path/to/tls-private-key-file>"
+        scored: true
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -399,21 +375,16 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -426,17 +397,17 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-        scored: false
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -446,14 +417,11 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false

--- a/cfg/k3s-cis-1.24/node.yaml
+++ b/cfg/k3s-cis-1.24/node.yaml
@@ -156,7 +156,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -179,7 +179,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -202,7 +202,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
@@ -215,7 +215,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -241,7 +241,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -264,7 +264,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -283,7 +283,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -308,7 +308,7 @@ groups:
       - id: 4.2.8
         text: "Ensure that the --hostname-override argument is not set (Automated)"
         type: "skip"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
@@ -321,7 +321,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -342,7 +342,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -361,7 +361,7 @@ groups:
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -384,7 +384,7 @@ groups:
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -407,7 +407,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:

--- a/cfg/k3s-cis-1.24/policies.yaml
+++ b/cfg/k3s-cis-1.24/policies.yaml
@@ -152,8 +152,8 @@ groups:
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
         remediation: |
-          Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          Review the use of capabilities in applications running on your cluster. Where a namespace
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/k3s-cis-1.7/config.yaml
+++ b/cfg/k3s-cis-1.7/config.yaml
@@ -23,32 +23,42 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
 
   etcd:
     bins:
       - containerd
-    datadirs:
-      - /var/lib/rancher/k3s/server/db/etcd
-  node:
-    components:
-      - kubelet
-      - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+etcd:
+  components:
+    - etcd
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  etcd:
+    confs: /var/lib/rancher/k3s/server/db/etcd/config
 
-  policies:
-    components:
-      - policies
+node:
+  components:
+    - kubelet
+    - proxy
+
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+
+policies:
+  components:
+    - policies

--- a/cfg/k3s-cis-1.7/controlplane.yaml
+++ b/cfg/k3s-cis-1.7/controlplane.yaml
@@ -35,7 +35,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/cfg/k3s-cis-1.7/etcd.yaml
+++ b/cfg/k3s-cis-1.7/etcd.yaml
@@ -10,128 +10,135 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 4 'client-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: and
           test_items:
-            - flag: "cert-file"
-              set: true
-            - flag: "key-file"
-              set: true
+            - path: "{.client-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
+            - path: "{.client-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
         remediation: |
-          Follow the etcd service documentation and configure TLS encryption.
-          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
-          on the master node and set the below parameters.
-          --cert-file=</path/to/ca-file>
-          --key-file=</path/to/key-file>
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom cert and key files.
+        scored: false
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 4 'client-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit_config: "cat $etcdconf"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--client-cert-auth"
-              set: true
-            - flag: "client-cert-auth"
+            - path: "{.client-transport-security.client-cert-auth}"
               compare:
                 op: eq
                 value: true
-              set: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
-          node and set the below parameter.
-          --client-cert-auth="true"
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --client-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable client certificate authentication.
+        scored: false
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "if grep -q '^auto-tls' $etcdconf;then grep '^auto-tls' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: or
           test_items:
-            - flag: "--auto-tls"
-              set: false
-            - flag: "--auto-tls"
+            - path: "{.client-transport-security.auto-tls}"
               compare:
                 op: eq
                 value: false
+            - path: "{.client-transport-security.auto-tls}"
+              set: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
           node and either remove the --auto-tls parameter or set it to false.
-            --auto-tls=false
-        scored: true
+          client-transport-security:
+            auto-tls: false
+        scored: false
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep -E 'cert-file|key-file'"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: and
           test_items:
-            - flag: "cert-file"
-              set: true
-            - flag: "key-file"
-              set: true
+            - path: "{.peer-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.crt"
+            - path: "{.peer-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.key"
         remediation: |
-          Follow the etcd service documentation and configure peer TLS encryption as appropriate
-          for your etcd cluster.
-          Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameters.
-          --peer-client-file=</path/to/peer-cert-file>
-          --peer-key-file=</path/to/peer-key-file>
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates peer cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom peer cert and key files.
+        scored: false
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep -A 4 'peer-transport-security' $etcdconf | grep 'client-cert-auth'"
+        audit_config: "cat $etcdconf"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--client-cert-auth"
-              set: true
-            - flag: "client-cert-auth"
+            - path: "{.peer-transport-security.client-cert-auth}"
               compare:
                 op: eq
                 value: true
-              set: true
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
-          node and set the below parameter.
-          --peer-client-cert-auth=true
-        scored: true
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --peer-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable peer client certificate authentication.
+        scored: false
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "if grep -q '^peer-auto-tls' $etcdconf;then grep '^peer-auto-tls' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           bin_op: or
           test_items:
-            - flag: "--peer-auto-tls"
-              set: false
-            - flag: "--peer-auto-tls"
+            - path: "{.peer-transport-security.auto-tls}"
               compare:
                 op: eq
                 value: false
-              set: true
+            - path: "{.peer-transport-security.auto-tls}"
+              set: false
         remediation: |
-          Edit the etcd pod specification file $etcdconf on the master
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --peer-auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
           node and either remove the --peer-auto-tls parameter or set it to false.
-          --peer-auto-tls=false
-        scored: true
+          peer-transport-security:
+            auto-tls: false
+        scored: false
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
-        audit: "if grep -q 'trusted-ca-file' $etcdconf;then grep 'trusted-ca-file' $etcdconf;else echo 'notset';fi"
+        audit_config: "cat $etcdconf"
         tests:
           test_items:
-            - flag: "trusted-ca-file"
-              set: true
+            - path: "{.peer-transport-security.trusted-ca-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt"
         remediation: |
-          [Manual test]
-          Follow the etcd documentation and create a dedicated certificate authority setup for the
-          etcd service.
-          Then, edit the etcd pod specification file $etcdconf on the
-          master node and set the below parameter.
-          --trusted-ca-file=</path/to/ca-file>
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates a unique certificate authority for etcd.
+          This is located at /var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use a shared certificate authority.
         scored: false

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -19,10 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 600 $apiserverconf
           Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -33,9 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
           Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -49,9 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
           Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -62,9 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
           Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -78,9 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
           Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -91,9 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
           Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -108,10 +101,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
           Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -123,18 +114,13 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
           Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
-        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -143,14 +129,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
-          Not Applicable.
+          By default, K3s sets the CNI file permissions to 644.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-        type: skip
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -162,24 +148,27 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-          Not Applicable.
-        scored: false
+        scored: true
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a $etcddatadir"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
@@ -190,17 +179,14 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
-        type: "skip"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -224,12 +210,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -244,7 +230,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,7 +242,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -271,7 +257,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -300,7 +286,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -309,14 +295,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -325,17 +311,17 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -343,27 +329,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "token-auth-file=<path>"
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -375,47 +363,46 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+            - "kubelet-client-certificate=<path/to/client-cert-file>"
+            - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        type: "skip"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
         remediation: |
-          Follow the Kubernetes documentation and setup the TLS connection between
-          the apiserver and kubelets. Then, edit the API server pod specification file
-          $apiserverconf on the control plane node and set the
-          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
-          --kubelet-certificate-authority=<ca-string>
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "kubelet-certificate-authority=<path/to/ca-cert-file>"
         scored: true
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -423,15 +410,15 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -439,14 +426,14 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -454,14 +441,14 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -470,15 +457,15 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,EventRateLimit,..."
+            - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -489,9 +476,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.11
@@ -504,10 +492,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12
@@ -526,16 +517,13 @@ groups:
                 op: has
                 value: "PodSecurityPolicy"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.
-          --enable-admission-plugins=...,SecurityContextDeny,...
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -546,15 +534,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -565,14 +554,15 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -580,16 +570,16 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.16
         text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -600,14 +590,15 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.17
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -615,30 +606,28 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.2.18
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
-          Permissive.
+          kube-apiserver-arg:
+            - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -646,17 +635,15 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+            - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -664,17 +651,15 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -682,29 +667,30 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-          Permissive.
+          Permissive, per CIS guidelines,
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+            - "request-timeout=300s"
         scored: false
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -715,30 +701,36 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+            - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:
@@ -747,11 +739,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-certfile=<path>"
+            - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.26
@@ -765,60 +758,61 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "tls-cert-file=<path>"
+            - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.27
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.28
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.30
         text: "Ensure that encryption providers are appropriately configured (Manual)"
-        type: "skip"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -826,14 +820,16 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
-      - id: 1.2.32
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+      - id: 1.2.31
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -841,36 +837,32 @@ groups:
                 op: valid_elements
                 value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
         remediation: |
-          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
-          on the control plane node and set the below parameter.
-          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,
-          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
-          TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
-        scored: false
+          By default, the K3s kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments.
+          If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements.
+          If this check fails, remove any custom configuration around `tls-cipher-suites` or update the /etc/rancher/k3s/config.yaml file to match the default by adding the following:
+          kube-apiserver-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+        scored: true
 
   - id: 1.3
     text: "Controller Manager"
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+            - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -878,14 +870,15 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -893,40 +886,43 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -938,10 +934,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+            - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -958,8 +955,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -976,14 +975,15 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "profiling=true"
         scored: true
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:
@@ -995,6 +995,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "bind-address=<IP>"
         scored: true

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -151,7 +151,7 @@ groups:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
           else
             echo "permissions=700"
@@ -319,7 +319,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -335,7 +335,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -349,7 +349,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -369,7 +369,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -387,7 +387,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -400,7 +400,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -416,7 +416,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -431,7 +431,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -446,7 +446,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -463,7 +463,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -521,7 +521,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -541,7 +541,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -560,7 +560,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -577,7 +577,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -596,7 +596,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -612,7 +612,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -625,7 +625,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -641,7 +641,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -657,7 +657,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -673,7 +673,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -688,7 +688,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -709,7 +709,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -724,8 +724,8 @@ groups:
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -m -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
           else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
@@ -747,7 +747,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
+        audit: "journalctl -m -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
         tests:
           bin_op: and
           test_items:
@@ -766,7 +766,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -780,7 +780,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -794,7 +794,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -809,7 +809,7 @@ groups:
       - id: 1.2.30
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
@@ -827,7 +827,7 @@ groups:
 
       - id: 1.2.31
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -847,7 +847,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -860,7 +860,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -876,7 +876,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -892,7 +892,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -906,7 +906,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -920,7 +920,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -964,7 +964,7 @@ groups:
     checks:
       - id: 1.4.1
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1"
         tests:
           test_items:
             - flag: "--profiling"
@@ -981,7 +981,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -137,9 +137,7 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
           test_items:
@@ -147,7 +145,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown root:root <path/to/cni/files>
+          chown root:root /var/lib/cni/networks/<filename>
         scored: true
 
       - id: 1.1.11

--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -312,7 +312,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -331,7 +331,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -621,7 +621,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
@@ -637,7 +637,7 @@ groups:
           set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=30"
-        scored: true
+        scored: false
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
@@ -653,7 +653,7 @@ groups:
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=10"
-        scored: true
+        scored: false
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
@@ -669,7 +669,7 @@ groups:
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=100"
-        scored: true
+        scored: false
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"

--- a/cfg/k3s-cis-1.7/node.yaml
+++ b/cfg/k3s-cis-1.7/node.yaml
@@ -292,7 +292,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/cfg/k3s-cis-1.7/node.yaml
+++ b/cfg/k3s-cis-1.7/node.yaml
@@ -152,7 +152,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -174,7 +174,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -197,7 +197,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
@@ -209,7 +209,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -236,7 +236,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -259,7 +259,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -282,7 +282,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -296,7 +296,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -321,7 +321,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -340,7 +340,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -363,7 +363,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -387,7 +387,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -408,7 +408,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/cfg/k3s-cis-1.7/node.yaml
+++ b/cfg/k3s-cis-1.7/node.yaml
@@ -19,9 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example, chmod 600 $kubeletsvc
-          Not Applicable - All configuration is passed in as arguments at container run time.
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.2
@@ -32,16 +31,15 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
           Not Applicable.
            All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -53,11 +51,11 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chmod 600 $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
-        audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -65,7 +63,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
@@ -84,7 +82,7 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
+        audit: 'stat -c %U:%G $kubeletkubeconfig'
         tests:
           test_items:
             - flag: root:root
@@ -95,8 +93,8 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"
@@ -105,19 +103,22 @@ groups:
                 value: "600"
         remediation: |
           Run the following command to modify the file permissions of the
-          --client-ca-file chmod 600 <filename>
-        scored: false
+          --client-ca-file chmod 600 $kubeletcafile
+        scored: true
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root
+              compare:
+                op: eq
+                value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
-          chown root:root <filename>
-        scored: false
+          chown root:root $kubeletcafile
+        scored: true
 
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
@@ -130,8 +131,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chmod 600 $kubeletconf
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.10
@@ -142,10 +143,8 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chown root:root $kubeletconf
           Not Applicable.
-          All configuration is passed in as arguments at container run time.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
         scored: true
 
   - id: 4.2
@@ -162,20 +161,20 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -185,38 +184,32 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/agent/client-ca.crt
         scored: true
 
       - id: 4.2.4
-        text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        text: "Verify that the --read-only-port argument is set to 0 (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -230,19 +223,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
-        scored: false
+          systemctl restart k3s.service
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -255,21 +249,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -282,41 +272,31 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-          Permissive.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kubelet-arg:
+            - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.7
-        text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
+        text: "Ensure that the --hostname-override argument is not set (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
-        audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -330,19 +310,18 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "event-qps=<value>"
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.9
-        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -350,23 +329,18 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
-        scored: false
+         By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+         They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+         If for some reason you need to provide your own certificate and key, you can set the
+         the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+         kubelet-arg:
+         - "tls-cert-file=<path/to/tls-cert-file>"
+         - "tls-private-key-file=<path/to/tls-private-key-file>"
+        scored: true
 
       - id: 4.2.10
-        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -380,20 +354,16 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-        scored: false
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
 
       - id: 4.2.11
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -407,18 +377,17 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-          Not Applicable.
-        scored: false
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -428,21 +397,18 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -450,5 +416,7 @@ groups:
               path: '{.podPidsLimit}'
         remediation: |
           Decide on an appropriate level for this parameter and set it,
-          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `podPidsLimit` to
+          kubelet-arg:
+            - "pod-max-pids=<value>"
         scored: false

--- a/cfg/k3s-cis-1.7/policies.yaml
+++ b/cfg/k3s-cis-1.7/policies.yaml
@@ -43,20 +43,14 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        audit: check_for_default_sa.sh
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
+        type: "manual"
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
         scored: false
+
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"

--- a/cfg/k3s-cis-1.7/policies.yaml
+++ b/cfg/k3s-cis-1.7/policies.yaml
@@ -43,7 +43,6 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "skip"
         audit: check_for_default_sa.sh
         tests:
           test_items:
@@ -57,7 +56,6 @@ groups:
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-          Permissive - Kubernetes provides default service accounts to be used.
         scored: false
 
       - id: 5.1.6
@@ -138,29 +136,23 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.6
@@ -199,8 +191,8 @@ groups:
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
         remediation: |
-          Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          Review the use of capabilities in applications running on your cluster. Where a namespace
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 
@@ -242,10 +234,8 @@ groups:
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
-        type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-          Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
 
   - id: 5.4
@@ -310,9 +300,7 @@ groups:
 
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
-        type: "skip"
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.
-          Permissive - Kubernetes provides a default namespace.
         scored: false

--- a/cfg/k3s-cis-1.8/config.yaml
+++ b/cfg/k3s-cis-1.8/config.yaml
@@ -1,0 +1,54 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml
+
+master:
+  components:
+    - apiserver
+    - kubelet
+    - scheduler
+    - controllermanager
+    - etcd
+    - policies
+  apiserver:
+    bins:
+      - containerd
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  scheduler:
+    bins:
+      - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
+  controllermanager:
+    bins:
+      - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
+  etcd:
+    bins:
+      - containerd
+
+etcd:
+  confs: /var/lib/rancher/k3s/server/db/etcd/config
+
+node:
+  components:
+    - kubelet
+    - proxy
+  kubelet:
+    bins:
+      - containerd
+    confs:
+      - /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+policies:
+  components:
+    - policies

--- a/cfg/k3s-cis-1.8/controlplane.yaml
+++ b/cfg/k3s-cis-1.8/controlplane.yaml
@@ -37,7 +37,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/cfg/k3s-cis-1.8/controlplane.yaml
+++ b/cfg/k3s-cis-1.8/controlplane.yaml
@@ -1,0 +1,62 @@
+---
+controls:
+version: "k3s-cis-1.8"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+
+      - id: 3.1.2
+        text: "Service account token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of service account tokens.
+        scored: false
+
+      - id: 3.1.3
+        text: "Bootstrap token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of bootstrap tokens.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Review the audit policy provided for the cluster and ensure that it covers
+          at least the following areas,
+          - Access to Secrets managed by the cluster. Care should be taken to only
+            log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in
+            order to avoid risk of logging sensitive data.
+          - Modification of Pod and Deployment objects.
+          - Use of `pods/exec`, `pods/portforward`, `pods/proxy` and `services/proxy`.
+          For most requests, minimally logging at the Metadata level is recommended
+          (the most basic level of logging).
+        scored: false

--- a/cfg/k3s-cis-1.8/etcd.yaml
+++ b/cfg/k3s-cis-1.8/etcd.yaml
@@ -1,0 +1,144 @@
+---
+controls:
+version: "k3s-cis-1.8"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          bin_op: and
+          test_items:
+            - path: "{.client-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.crt"
+            - path: "{.client-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/server-client.key"
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom cert and key files.
+        scored: false
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          test_items:
+            - path: "{.client-transport-security.client-cert-auth}"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --client-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable client certificate authentication.
+        scored: false
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          bin_op: or
+          test_items:
+            - path: "{.client-transport-security.auto-tls}"
+              compare:
+                op: eq
+                value: false
+            - path: "{.client-transport-security.auto-tls}"
+              set: false
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+          client-transport-security:
+            auto-tls: false
+        scored: false
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          bin_op: and
+          test_items:
+            - path: "{.peer-transport-security.cert-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.crt"
+            - path: "{.peer-transport-security.key-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-server-client.key"
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates peer cert and key files for etcd.
+          These are located in /var/lib/rancher/k3s/server/tls/etcd/.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use custom peer cert and key files.
+        scored: false
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          test_items:
+            - path: "{.peer-transport-security.client-cert-auth}"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s sets the --peer-cert-auth parameter to true.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to disable peer client certificate authentication.
+        scored: false
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          bin_op: or
+          test_items:
+            - path: "{.peer-transport-security.auto-tls}"
+              compare:
+                op: eq
+                value: false
+            - path: "{.peer-transport-security.auto-tls}"
+              set: false
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s does not set the --peer-auto-tls parameter.
+          If this check fails, edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          peer-transport-security:
+            auto-tls: false
+        scored: false
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        audit_config: "cat $etcdconf"
+        tests:
+          test_items:
+            - path: "{.peer-transport-security.trusted-ca-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt"
+        remediation: |
+          If running on with sqlite or a external DB, etcd checks are Not Applicable.
+          When running with embedded-etcd, K3s generates a unique certificate authority for etcd.
+          This is located at /var/lib/rancher/k3s/server/tls/etcd/peer-ca.crt.
+          If this check fails, ensure that the configuration file $etcdconf
+          has not been modified to use a shared certificate authority.
+        scored: false

--- a/cfg/k3s-cis-1.8/master.yaml
+++ b/cfg/k3s-cis-1.8/master.yaml
@@ -136,21 +136,17 @@ groups:
         scored: true
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-        type: skip
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown root:root <path/to/cni/files>
-        scored: false
+          chown root:root /var/lib/cni/networks/<filename>
+        scored: true
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"

--- a/cfg/k3s-cis-1.8/master.yaml
+++ b/cfg/k3s-cis-1.8/master.yaml
@@ -312,7 +312,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -331,7 +331,7 @@ groups:
           If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -603,7 +603,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
@@ -619,7 +619,7 @@ groups:
           set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=30"
-        scored: true
+        scored: false
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
@@ -635,7 +635,7 @@ groups:
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=10"
-        scored: true
+        scored: false
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
@@ -651,7 +651,7 @@ groups:
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=100"
-        scored: true
+        scored: false
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"

--- a/cfg/k3s-cis-1.8/master.yaml
+++ b/cfg/k3s-cis-1.8/master.yaml
@@ -151,7 +151,7 @@ groups:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
           else
             echo "permissions=700"
@@ -319,7 +319,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -335,7 +335,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -349,7 +349,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -369,7 +369,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: and
           test_items:
@@ -387,7 +387,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -401,7 +401,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -417,7 +417,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -432,7 +432,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -447,7 +447,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -464,7 +464,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -483,7 +483,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -522,7 +522,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -542,7 +542,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -561,7 +561,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -578,7 +578,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -594,7 +594,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -607,7 +607,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -623,7 +623,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -639,7 +639,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -655,7 +655,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -670,7 +670,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -691,7 +691,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -706,8 +706,8 @@ groups:
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: |
-          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -m -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
           else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
@@ -729,7 +729,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
+        audit: "journalctl -m -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
         tests:
           bin_op: and
           test_items:
@@ -748,7 +748,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -763,7 +763,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -778,7 +778,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -793,7 +793,7 @@ groups:
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
@@ -811,7 +811,7 @@ groups:
 
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:
           test_items:
             - flag: "--tls-cipher-suites"
@@ -831,7 +831,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -844,7 +844,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -860,7 +860,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -876,7 +876,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -890,7 +890,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -905,7 +905,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -926,7 +926,7 @@ groups:
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -949,7 +949,7 @@ groups:
     checks:
       - id: 1.4.1
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -966,7 +966,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -m -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/cfg/k3s-cis-1.8/master.yaml
+++ b/cfg/k3s-cis-1.8/master.yaml
@@ -1,0 +1,989 @@
+---
+controls:
+version: "k3s-cis-1.8"
+id: 1
+text: "Control Plane Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Not Applicable.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
+        scored: true
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        type: skip
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Not Applicable.
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        type: "skip"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown -R root:root /var/lib/rancher/k3s/server/tls
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          By default, K3s sets the --anonymous-auth argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "token-auth-file=<path>"
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: "DenyServiceExternalIPs"
+              set: true
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=DenyServiceExternalIPs"
+        scored: true
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+            - "kubelet-client-certificate=<path/to/client-cert-file>"
+            - "kubelet-client-key=<path/to/client-key-file>"
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "kubelet-certificate-authority=<path/to/ca-cert-file>"
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "authorization-mode=AlwaysAllow"
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,EventRateLimit,..."
+            - "admission-control-config-file=<path/to/configuration/file>"
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=AlwaysAdmit"
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,AlwaysPullImages,..."
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "skip"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=ServiceAccount"
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "disable-admission-plugins=...,NamespaceLifecycle,..."
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+            - "enable-admission-plugins=...,NodeRestriction,..."
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "profiling=true"
+        scored: true
+
+      - id: 1.2.17
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example,
+          kube-apiserver-arg:
+            - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+            - "audit-log-maxage=30"
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxbackup=10"
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+            - "audit-log-maxsize=100"
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--request-timeout"
+        remediation: |
+          Permissive, per CIS guidelines,
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+            - "request-timeout=300s"
+        scored: false
+
+      - id: 1.2.22
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+            - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.23
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "service-account-key-file=<path>"
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+              set: true
+            - flag: "--etcd-keyfile"
+              set: true
+        remediation: |
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-certfile=<path>"
+            - "etcd-keyfile=<path>"
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+              set: true
+            - flag: "--tls-private-key-file"
+              set: true
+        remediation: |
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "tls-cert-file=<path>"
+            - "tls-private-key-file=<path>"
+        scored: true
+
+      - id: 1.2.26
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "client-ca-file=<path>"
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+            - "etcd-cafile=<path>"
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
+        scored: false
+
+      - id: 1.2.29
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
+        scored: false
+
+      - id: 1.2.30
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
+        remediation: |
+          By default, the K3s kube-apiserver complies with this test. Changes to these values may cause regression, therefore ensure that all apiserver clients support the new TLS configuration before applying it in production deployments.
+          If a custom TLS configuration is required, consider also creating a custom version of this rule that aligns with your requirements.
+          If this check fails, remove any custom configuration around `tls-cipher-suites` or update the /etc/rancher/k3s/config.yaml file to match the default by adding the following:
+          kube-apiserver-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+        scored: true
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+            - "terminated-pod-gc-threshold=10"
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "profiling=true"
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "use-service-account-credentials=false"
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "service-account-private-key-file=<path>"
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "root-ca-file=<path>"
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+            - "feature-gate=RotateKubeletServerCertificate"
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+              set: true
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+            - "bind-address=<IP>"
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'profiling'"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+              set: true
+        remediation: |
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "profiling=true"
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+              set: true
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+            - "bind-address=<IP>"
+        scored: true

--- a/cfg/k3s-cis-1.8/node.yaml
+++ b/cfg/k3s-cis-1.8/node.yaml
@@ -292,7 +292,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/cfg/k3s-cis-1.8/node.yaml
+++ b/cfg/k3s-cis-1.8/node.yaml
@@ -152,7 +152,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -174,7 +174,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -197,7 +197,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -m -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -m -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
@@ -209,7 +209,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -236,7 +236,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -259,7 +259,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -282,7 +282,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -296,7 +296,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -321,7 +321,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -340,7 +340,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -363,7 +363,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -387,7 +387,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -408,7 +408,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/cfg/k3s-cis-1.8/node.yaml
+++ b/cfg/k3s-cis-1.8/node.yaml
@@ -1,0 +1,422 @@
+---
+controls:
+version: "k3s-cis-1.8"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet service file, all configuration is passed in as arguments at runtime.
+          Not Applicable.
+           All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $proxykubeconfig
+        scored: true
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: true
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: 'stat -c %U:%G $kubeletkubeconfig'
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $kubeletcafile"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 600 $kubeletcafile
+        scored: true
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G $kubeletcafile"
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root $kubeletcafile
+        scored: true
+
+      - id: 4.1.9
+        text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        type: "skip"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
+        scored: true
+
+      - id: 4.1.10
+        text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        type: "skip"
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Not Applicable.
+          The kubelet is embedded in the k3s process. There is no kubelet config file, all configuration is passed in as arguments at runtime.
+        scored: true
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
+          systemctl daemon-reload
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
+          systemctl daemon-reload
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/agent/client-ca.crt
+        scored: true
+
+      - id: 4.2.4
+        text: "Verify that the --read-only-port argument is set to 0 (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kubelet-arg:
+            - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kubelet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
+          systemctl daemon-reload
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kubelet-arg:
+            - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --hostname-override argument is not set (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        type: "skip"
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
+        scored: false
+
+      - id: 4.2.8
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: gte
+                value: 0
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              set: false
+          bin_op: or
+        remediation: |
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kubelet-arg:
+            - "event-qps=<value>"
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '/var/lib/rancher/k3s/agent/serving-kubelet.crt'
+            - flag: --tls-private-key-file
+              path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
+        remediation: |
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+            - "tls-cert-file=<path/to/tls-cert-file>"
+            - "tls-private-key-file=<path/to/tls-private-key-file>"
+        scored: true
+
+      - id: 4.2.10
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.11
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: true
+
+      - id: 4.2.12
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
+              compare:
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        remediation: |
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+            - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+          or to a subset of these values.
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that a limit is set on pod PIDs (Manual)"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --pod-max-pids
+              path: '{.podPidsLimit}'
+        remediation: |
+          Decide on an appropriate level for this parameter and set it,
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `podPidsLimit` to
+          kubelet-arg:
+            - "pod-max-pids=<value>"
+        scored: false

--- a/cfg/k3s-cis-1.8/policies.yaml
+++ b/cfg/k3s-cis-1.8/policies.yaml
@@ -1,0 +1,306 @@
+---
+controls:
+version: "k3s-cis-1.8"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to Secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        audit: check_for_default_sa.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+      - id: 5.1.9
+        text: "Minimize access to create persistent volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to PersistentVolume objects in the cluster.
+        scored: false
+
+      - id: 5.1.10
+        text: "Minimize access to the proxy sub-resource of nodes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the proxy sub-resource of node objects.
+        scored: false
+
+      - id: 5.1.11
+        text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
+        scored: false
+
+      - id: 5.1.12
+        text: "Minimize access to webhook configuration objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
+        scored: false
+
+      - id: 5.1.13
+        text: "Minimize access to the service account token creation (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the token sub-resource of serviceaccount objects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Standards"
+    checks:
+      - id: 5.2.1
+        text: "Ensure that the cluster has at least one active policy control mechanism in place (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that either Pod Security Admission or an external policy control system is in place
+          for every namespace which contains user workloads.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of privileged containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of privileged containers.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostPID` containers.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostIPC` containers.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostNetwork` containers.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
+        scored: true
+
+      - id: 5.2.7
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
+          or `MustRunAs` with the range of UIDs not including 0, is set.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with the `NET_RAW` capability.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that `allowedCapabilities` is not present in policies for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.10
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilities in applications running on your cluster. Where a namespace
+          contains applications which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+      - id: 5.2.11
+        text: "Minimize the admission of Windows HostProcess containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
+        scored: false
+
+      - id: 5.2.12
+        text: "Minimize the admission of HostPath volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `hostPath` volumes.
+        scored: false
+
+      - id: 5.2.13
+        text: "Minimize the admission of containers which use HostPorts (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers which use `hostPort` sections.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports NetworkPolicies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using Secrets as files over Secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          If possible, rewrite application code to read Secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the Secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use `securityContext` to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply SecurityContext to your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply SecurityContexts to your Pods. For a
+          suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/cfg/k3s-cis-1.8/policies.yaml
+++ b/cfg/k3s-cis-1.8/policies.yaml
@@ -43,20 +43,14 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        audit: check_for_default_sa.sh
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
+        type: "manual"
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
         scored: false
+
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"

--- a/cfg/rke-cis-1.23/policies.yaml
+++ b/cfg/rke-cis-1.23/policies.yaml
@@ -42,16 +42,8 @@ groups:
         scored: false
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used. (Automated)"
-        type: "skip"
-        audit: check_for_default_sa.sh
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.

--- a/cfg/rke-cis-1.24/policies.yaml
+++ b/cfg/rke-cis-1.24/policies.yaml
@@ -44,14 +44,6 @@ groups:
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         type: "manual"
-        audit: check_for_default_sa.sh
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.

--- a/cfg/rke-cis-1.7/policies.yaml
+++ b/cfg/rke-cis-1.7/policies.yaml
@@ -43,21 +43,12 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "skip"
-        audit: check_for_default_sa.sh
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
+        type: "manual"
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-          Permissive - Kubernetes provides default service accounts to be used.
         scored: false
 
       - id: 5.1.6


### PR DESCRIPTION
### Background
- An effort to overhaul the K3s and RKE2 scans is being undertaken in the [rancher/security-scan](https://github.com/rancher/security-scan) repo. These changes are being upstreamed into the kube-bench project. 
- This is a combination of the following PRs:
  - https://github.com/rancher/security-scan/pull/221
  - https://github.com/rancher/security-scan/pull/219
  - https://github.com/rancher/security-scan/pull/228
  - https://github.com/rancher/security-scan/pull/232
### Changes
- Overhaul existing K3s v1.24 and v1.7 scans, ensuring that
  - All checks have proper remeditation sections that give specific details on K3s, not just the general CIS scans
  - All checks use the `Automated` and `Manual` correctly, identifiying what K3s by default will handle, and when user action in needed.
  - All checks have proper audit sections that work. Several were written wrong. 
- Add K3s cis 1.8 scan with the same overhaul

### Verification

#### k3s-cis-1.24

Tested on v1.24.17+k3s1 with the following config.yaml (standard hardening config from [docs](https://docs.k3s.io/security/hardening-guide))
```
#/etc/rancher/k3s/config.yaml
cluster-init: true
protect-kernel-defaults: true
secrets-encryption: true
kube-controller-manager-arg:
  - 'terminated-pod-gc-threshold=10'
kubelet-arg:
  - 'streaming-connection-idle-timeout=5m'
  - 'make-iptables-util-chains=true'
  - 'event-qps=0'
  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
kube-apiserver-arg:
  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
  - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
  - 'audit-log-maxage=30'
  - 'audit-log-maxbackup=10'
  - 'audit-log-maxsize=100'
  - 'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount,PodSecurityPolicy'
```
| Master | PR |
| - | - |
| ![image](https://github.com/user-attachments/assets/edc21628-a911-4cb3-ab29-283c7fe72b7f) |  ![image](https://github.com/user-attachments/assets/801fe7db-50ad-4817-b098-87183a8b8e47) |

#### k3s-cis-1.7

Tested on v1.25+k3s4 with the following config.yaml (standard hardening config from [docs](https://docs.k3s.io/security/hardening-guide))
```
cluster-init: true
protect-kernel-defaults: true
secrets-encryption: true
kube-controller-manager-arg:
  - 'terminated-pod-gc-threshold=10'
kubelet-arg:
  - 'streaming-connection-idle-timeout=5m'
  - 'make-iptables-util-chains=true'
  - 'event-qps=0'
  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
kube-apiserver-arg:
  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
  - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
  - 'audit-log-maxage=30'
  - 'audit-log-maxbackup=10'
  - 'audit-log-maxsize=100'
  - 'admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml'
```
| Master | PR |
| - | - |
| ![image](https://github.com/user-attachments/assets/2a5c9c86-c50e-4801-b529-d4be4a9a5a91) |![image](https://github.com/user-attachments/assets/488dc5cd-9e76-46cb-b1de-f8a12b120c3d) | 


#### k3s-cis-1.8

Tested on v1.28.11+k3s1 with the same config as k3s-cis-1.7
![image](https://github.com/user-attachments/assets/e0ece82d-ff17-483f-a26a-eebfcc3b43f7)







Note: CIS-1.9 scans are on the TODO for RKE2 and K3s, they should be incoming within the next month or two. 
