### PR TITLE
FIXING RKE2-CIS-1.24 CHECKS

### DIFF
--- a/cfg/rke2-cis-1.24/master.yaml
+++ b/cfg/rke2-cis-1.24/master.yaml
@@ -154,6 +154,7 @@ groups:
         tests:
           test_items:
             - flag: "root:root"
+        type: manual
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
@@ -313,6 +314,7 @@ groups:
                 op: bitmask
                 value: "600"
               set: true
+        type: manual
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
@@ -979,7 +981,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
-        scored: true
+        scored: false
         type: skip
 
       - id: 1.3.7

--- a/cfg/rke2-cis-1.24/node.yaml
+++ b/cfg/rke2-cis-1.24/node.yaml
@@ -440,6 +440,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+        type: skip
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"


### PR DESCRIPTION
. **MASTER**:
            a. Checks 1.1.10,1.1.20 are manual according to https://docs.rke2.io/security/cis_self_assessment124#1110-ensure-that-the-container-network-interface-file-ownership-is-set-to-root-manual and https://docs.rke2.io/security/cis_self_assessment124#1110-ensure-that-the-container-network-interface-file-ownership-is-set-to-root-manual respectively.
            b. Check 1.3.6 is not relevant to an RKE2 cluster as RKE2 rotates TLS certificates internally - https://github.com/rancher/dashboard/issues/4485. We will skip it and not score it
    2. **NODE**:
            a. Check 4.2.12 is the node-level equivalent of the master-level check 1.3.6 and is treated the same way.
@afdesk  request review please.