### PR TITLE
FIXING RKE-2-CIS-1.24 Checks

### DIFF
--- a/cfg/rke2-cis-1.24/master.yaml
+++ b/cfg/rke2-cis-1.24/master.yaml
@@ -148,12 +148,18 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          '/bin/sh -c "if [[ -e /etc/cni/net.d ]]; then
+          ps -fC "${kubeletbin:-kubelet}" | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          else
+          echo "File not found"
+          fi'
         use_multiple_values: true
         tests:
+          bin_op: or
           test_items:
             - flag: "root:root"
+            - flag: "File not found"
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
@@ -321,11 +327,18 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.key"
+        audit: |
+          '/bin/sh -c if test -e "/var/lib/rancher/rke2/server/tls/*.key"; then
+          stat -c "%a" "/var/lib/rancher/rke2/server/tls/*.key"
+          else
+          echo "File not found"
+          fi'
         use_multiple_values: true
         tests:
+          bin_op: or
           test_items:
             - flag: "permissions"
+            - flag: "File not found"
               compare:
                 op: eq
                 value: "600"
@@ -979,7 +992,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
-        scored: true
+        scored: false
         type: skip
 
       - id: 1.3.7

--- a/cfg/rke2-cis-1.24/node.yaml
+++ b/cfg/rke2-cis-1.24/node.yaml
@@ -440,7 +440,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
-
+        type: skip
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -fC $kubeletbin"


### PR DESCRIPTION
**MASTER**:
            a. Checks **1.1.10,1.1.2**: In The case of manual checks, ideally  the user also checks if the required configuration  files are present or not. We have augmented those checks to capture that information as well, and run the actual audit only when th corresponding configuration files are found.
            b. **Check 1.3.6**: is not relevant to an RKE2 cluster as RKE2 rotates TLS certificates internally - rancher/dashboard#4485. We will skip it and not score it

    2. **NODE**:
            a. Check 4.2.12 is the node-level equivalent of the master-level check 1.3.6 and is treated the same way.