### PR TITLE
Ensure 127.0.0.1 for the --bind-address parameter

### DIFF
--- a/cfg/cis-1.24/master.yaml
+++ b/cfg/cis-1.24/master.yaml
@@ -900,14 +900,11 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-            - flag: "--bind-address"
-              set: false
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
@@ -935,14 +932,11 @@ groups:
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
-            - flag: "--bind-address"
-              set: false
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf
           on the control plane node and ensure the correct value for the --bind-address parameter


### PR DESCRIPTION
If `--bind-address` of kube-scheduler and kube-controller-manager is not set it defaults to 0.0.0.0 (all interfaces) [1, 2].

The respective checks (1.3.7 and 1.4.2) should not accept the default bind-address value and should fail if `--bind-address` is not set.

[1] https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
[2] https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 

