### PR TITLE
fix: change the folder name for certificate files in rke-cis-1.7

### DIFF
--- a/cfg/rke-cis-1.7/master.yaml
+++ b/cfg/rke-cis-1.7/master.yaml
@@ -300,7 +300,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        audit: "check_files_owner_in_dir.sh /etc/kubernetes/ssl"
         tests:
           test_items:
             - flag: "true"
@@ -311,12 +311,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /etc/kubernetes/ssl/
         scored: true
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -327,12 +327,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
+          find /etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /node/etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
+        audit: "find /etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -343,7 +343,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          find /node/etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
+          find /etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
   - id: 1.2

--- a/cfg/rke-cis-1.7/node.yaml
+++ b/cfg/rke-cis-1.7/node.yaml
@@ -98,7 +98,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
+        audit: "stat -c permissions=%a /etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -112,7 +112,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
+        audit: "stat -c %U:%G /etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root


### PR DESCRIPTION
This PR changes the folder name for certificate files in rke-cis-1.7.

fixes #1746