### PR TITLE
VEX related improvements in the build process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ env:
   - CGO_ENABLED=0
   - KUBEBENCH_CFG=/etc/kube-bench/cfg
 builds:
-  - main: main.go
+  - main: .
     binary: kube-bench
     tags:
       - osusergo


### PR DESCRIPTION
This PR solves https://github.com/aquasecurity/kube-bench/discussions/1767 by compiling against the build directory instead of `main.go`. This will add the proper package path inside the binary and allow VEX entries to be matched against the kube-bench binary.

```
> go version -m dist/kube-bench | head -n 3
dist/kube-bench: go1.23.4
	path	github.com/aquasecurity/kube-bench
	mod	github.com/aquasecurity/kube-bench	(devel)	
```