### PR TITLE
fix(ci): add missed args for building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ CMD ["install"]
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF
+ARG KUBEBENCH_VERSION
+
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="kube-bench" \
       org.label-schema.vendor="Aqua Security Software Ltd." \

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -50,6 +50,8 @@ CMD ["install"]
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF
+ARG KUBEBENCH_VERSION
+
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="kube-bench" \
       org.label-schema.vendor="Aqua Security Software Ltd." \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -50,6 +50,8 @@ CMD ["install"]
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF
+ARG KUBEBENCH_VERSION
+
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="kube-bench" \
       org.label-schema.vendor="Aqua Security Software Ltd." \


### PR DESCRIPTION
in #1781 there were missed args in result images for labels in Dockerfiles.
this PR adds args for alpine based images.

```sh
$ make build-docker
$ docker inspect aquasec/kube-bench:5557601 | grep label
```

Before:
```sh
                "org.label-schema.build-date": "2025-01-21T06:29:34Z",
                "org.label-schema.description": "Run the CIS Kubernetes Benchmark tests",
                "org.label-schema.maintainer": "admin@aquasec.com",
                "org.label-schema.name": "kube-bench",
                "org.label-schema.release": "",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.summary": "Aqua security server",
                "org.label-schema.url": "https://github.com/aquasecurity/kube-bench",
                "org.label-schema.vcs-ref": "5557601",
                "org.label-schema.vcs-url": "https://github.com/aquasecurity/kube-bench",
                "org.label-schema.vendor": "Aqua Security Software Ltd.",
                "org.label-schema.version": ""
```
After:
```sh
                "org.label-schema.build-date": "2025-01-21T06:49:46Z",
                "org.label-schema.description": "Run the CIS Kubernetes Benchmark tests",
                "org.label-schema.maintainer": "admin@aquasec.com",
                "org.label-schema.name": "kube-bench",
                "org.label-schema.release": "v0.10.0",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.summary": "Aqua security server",
                "org.label-schema.url": "https://github.com/aquasecurity/kube-bench",
                "org.label-schema.vcs-ref": "5557601",
                "org.label-schema.vcs-url": "https://github.com/aquasecurity/kube-bench",
                "org.label-schema.vendor": "Aqua Security Software Ltd.",
                "org.label-schema.version": "v0.10.0"
```