### PR TITLE
Bump golang from 1.23.5 to 1.23.6 to fix CVE-2025-22866

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM golang:1.23.5 AS build
+FROM golang:1.23.6 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY makefile makefile
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/kube-bench
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.0


### PR DESCRIPTION
This is the scan result of Trivy.

```
usr/local/bin/kube-bench (gobinary)
===================================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                   Title                    │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22866 │ UNKNOWN  │ fixed  │ 1.23.5            │ 1.22.12, 1.23.6, 1.24.0-rc.3 │ Timing sidechannel for P-256 on ppc64le in │
│         │                │          │        │                   │                              │ crypto/internal/nistec                     │
│         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22866 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴────────────────────────────────────────────┘
```