### PR TITLE
ci: bump up Go version to 1.23.6 in Github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       - "LICENSE"
       - "NOTICE"
 env:
-  GO_VERSION: "1.23.5"
+  GO_VERSION: "1.23.6"
   KIND_VERSION: "v0.11.1"
   KIND_IMAGE: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
 env:
-  GO_VERSION: "1.22.7"
+  GO_VERSION: "1.23.6"
   KIND_VERSION: "v0.11.1"
   KIND_IMAGE: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
 


### PR DESCRIPTION
Kube-bench already uses Go v1.23.6, so the pipeline should use the same version for tests.