### PR TITLE
fix: suppress vulnerabilities in kubectl

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ uname := $(shell uname -s)
 BUILDX_PLATFORM ?= linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/s390x
 DOCKER_ORGS ?= aquasec public.ecr.aws/aquasecurity
 GOARCH ?= $@
-KUBECTL_VERSION ?= 1.31.0
+KUBECTL_VERSION ?= 1.33.0-alpha.1
 ARCH ?= $(shell go env GOARCH)
 
 ifneq ($(findstring Microsoft,$(shell uname -r)),)


### PR DESCRIPTION
kubectl has vulnerabilities in the stable version, it was fixed in `1.33.0-alpha.1` (https://github.com/kubernetes/kubectl/tree/v0.33.0-alpha.1).

before:
```sh
$ trivy i aquasec/kube-bench:v0.10.1 --severity HIGHaquasec/kube-bench:v0.10.1 
(alpine 3.21.2)Total: 0 (HIGH: 0)

usr/local/bin/kubectl (gobinary)Total: 2 (HIGH: 2)
┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2024-45338 │ HIGH     │ fixed  │ v0.26.0           │ 0.33.0         │ golang.org/x/net/html: Non-linear parsing of              │
│                  │                │          │        │                   │                │ case-insensitive content in golang.org/x/net/html         │
│                  │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-45338                │
├──────────────────┼────────────────┤          │        ├───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib           │ CVE-2024-34156 │          │        │ v1.22.5           │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message │
│                  │                │          │        │                   │                │ which contains deeply nested structures...                │
│                  │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘ 
```
after
```sh
$ trivy i aquasec/kube-bench:fcb6517 --severity HIGH
2025-02-11T16:15:35+06:00       INFO    [vuln] Vulnerability scanning is enabled
2025-02-11T16:15:35+06:00       INFO    [secret] Secret scanning is enabled
2025-02-11T16:15:35+06:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-02-11T16:15:35+06:00       INFO    [secret] Please see also https://aquasecurity.github.io/trivy/v0.59/docs/scanner/secret#recommendation for faster secret detection
2025-02-11T16:15:35+06:00       INFO    Detected OS     family="alpine" version="3.21.2"
2025-02-11T16:15:35+06:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.21" repository="3.21" pkg_num=29
2025-02-11T16:15:35+06:00       INFO    Number of language-specific files       num=2
2025-02-11T16:15:35+06:00       INFO    [gobinary] Detecting vulnerabilities...
2025-02-11T16:15:35+06:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.59/docs/scanner/vulnerability#severity-selection for details.aquasec/kube-bench:fcb6517 

(alpine 3.21.2)Total: 0 (HIGH: 0)
```
