### PR TITLE
Fix typo of applicaions which should have been applications

### DIFF
--- a/cfg/ack-1.0/policies.yaml
+++ b/cfg/ack-1.0/policies.yaml
@@ -132,7 +132,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications runnning on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.10/policies.yaml
+++ b/cfg/cis-1.10/policies.yaml
@@ -443,7 +443,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.20/policies.yaml
+++ b/cfg/cis-1.20/policies.yaml
@@ -146,7 +146,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.23/policies.yaml
+++ b/cfg/cis-1.23/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.24/policies.yaml
+++ b/cfg/cis-1.24/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.5/policies.yaml
+++ b/cfg/cis-1.5/policies.yaml
@@ -132,7 +132,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.6/policies.yaml
+++ b/cfg/cis-1.6/policies.yaml
@@ -132,7 +132,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.7/policies.yaml
+++ b/cfg/cis-1.7/policies.yaml
@@ -188,7 +188,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.8/policies.yaml
+++ b/cfg/cis-1.8/policies.yaml
@@ -188,7 +188,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/cis-1.9/policies.yaml
+++ b/cfg/cis-1.9/policies.yaml
@@ -289,7 +289,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/k3s-cis-1.23/policies.yaml
+++ b/cfg/k3s-cis-1.23/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rh-1.0/policies.yaml
+++ b/cfg/rh-1.0/policies.yaml
@@ -184,7 +184,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider
+          contains applications which do not require any Linux capabities to operate consider
           adding a SCC which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke-cis-1.23/policies.yaml
+++ b/cfg/rke-cis-1.23/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke-cis-1.24/policies.yaml
+++ b/cfg/rke-cis-1.24/policies.yaml
@@ -193,7 +193,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke-cis-1.7/policies.yaml
+++ b/cfg/rke-cis-1.7/policies.yaml
@@ -191,7 +191,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke2-cis-1.23/policies.yaml
+++ b/cfg/rke2-cis-1.23/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke2-cis-1.24/policies.yaml
+++ b/cfg/rke2-cis-1.24/policies.yaml
@@ -153,7 +153,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/rke2-cis-1.7/policies.yaml
+++ b/cfg/rke2-cis-1.7/policies.yaml
@@ -188,7 +188,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
 

--- a/cfg/tkgi-1.2.53/policies.yaml
+++ b/cfg/tkgi-1.2.53/policies.yaml
@@ -160,7 +160,7 @@ groups:
         type: "manual"
         remediation: |
           Review the use of capabilites in applications running on your cluster. Where a namespace
-          contains applicaions which do not require any Linux capabities to operate consider adding
+          contains applications which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
           Exception
           This is site-specific setting.

--- a/integration/testdata/Expected_output.data
+++ b/integration/testdata/Expected_output.data
@@ -385,7 +385,7 @@ UIDs not including 0.
 it is set to an empty array.
 
 5.2.9 Review the use of capabilites in applications running on your cluster. Where a namespace
-contains applicaions which do not require any Linux capabities to operate consider adding
+contains applications which do not require any Linux capabities to operate consider adding
 a PSP which forbids the admission of containers which do not drop all capabilities.
 
 5.3.1 If the CNI plugin in use does not support network policies, consideration should be given to


### PR DESCRIPTION
This PR fixes a simple typo of "applicaions" to "applications" in all files within this repo.