### PR TITLE
fix: Add default case to RKE CIS benchmark version selection

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -527,6 +527,8 @@ func getPlatformBenchmarkVersion(platform Platform) string {
 			return "rke-cis-1.24"
 		case "1.25", "1.26", "1.27":
 			return "rke-cis-1.7"
+		default:
+			return "rke-cis-1.7"
 		}
 	case "rke2r":
 		switch platform.Version {
@@ -535,6 +537,8 @@ func getPlatformBenchmarkVersion(platform Platform) string {
 		case "1.24":
 			return "rke2-cis-1.24"
 		case "1.25", "1.26", "1.27":
+			return "rke2-cis-1.7"
+		default:
 			return "rke2-cis-1.7"
 		}
 	}


### PR DESCRIPTION
This commit adds a default case to the switch statements for both "rancher" and "rke2" platforms. This ensures that a fallback CIS benchmark version ("rke-cis-1.7" and "rke2-cis-1.7" respectively) is returned when the Kubernetes version does not match any of the explicitly defined cases.