### PR TITLE
add necessary mounts for /var/vcap/data/jobs & sys

### DIFF
--- a/job-tkgi.yaml
+++ b/job-tkgi.yaml
@@ -23,6 +23,9 @@ spec:
             - name: var-vcap-jobs
               mountPath: /var/vcap/jobs
               readOnly: true
+            - name: var-vcap-data-jobs
+              mountPath: /var/vcap/data/jobs
+              readOnly: true
             - name: var-vcap-packages
               mountPath: /var/vcap/packages
               readOnly: true
@@ -32,6 +35,9 @@ spec:
             - name: var-vcap-sys
               mountPath: /var/vcap/sys
               readOnly: true
+            - name: var-vcap-data-sys
+              mountPath: /var/vcap/data/sys
+              readOnly: true
             - name: etc-kubernetes
               mountPath: /etc/kubernetes
               readOnly: true
@@ -40,6 +46,9 @@ spec:
         - name: var-vcap-jobs
           hostPath:
             path: "/var/vcap/jobs"
+        - name: var-vcap-data-jobs
+          hostPath:
+            path: "/var/vcap/data/jobs"
         - name: var-vcap-packages
           hostPath:
             path: "/var/vcap/packages"
@@ -49,6 +58,9 @@ spec:
         - name: var-vcap-sys
           hostPath:
             path: "/var/vcap/sys"
+        - name: var-vcap-data-sys
+          hostPath:
+            path: "/var/vcap/data/sys"
         - name: etc-kubernetes
           hostPath:
             path: "/etc/kubernetes"


### PR DESCRIPTION
Running kube-bench on TKGI with the provided job template will fail with errors like:
`14:55:43.616764 3064074 check.go:190] failed to run: "grep  ^tlsCertFile:\\s\\\"\\/var\\/vcap\\/jobs\\/kubelet\\/config\\/kubelet\\.pem\\\"\\ntlsPrivateKeyFile:\\s\\\"\\/var\\/vcap\\/jobs\\/kubelet\\/config\\/kubelet-key\\.pem\\\"$\n/var/vcap/jobs/kubelet/config/kubeletconfig.yml", output: "/bin/sh: /var/vcap/jobs/kubelet/config/kubeletconfig.yml: not found\n", error: exit status 127`

This is due to the fact that /var/vcap/jobs/<subdir> only contains symbolic links to /var/vcap/data/jobs/<subdir>/<uuid>
To actually read - for example - the kubeletconfig.yml the /var/vcap/data/jobs directory needs to be mounted aswell.

Likewise /var/vcap/sys is a symlink pointing to /var/vcap/data/sys