### PR TITLE
1.1.15, 1.1.17 of `rke2-cis-1.7` fails

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -60,6 +60,7 @@ master:
       - /etc/kubernetes/scheduler.conf
       - /var/lib/kube-scheduler/kubeconfig
       - /var/lib/kube-scheduler/config.yaml
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
       - /system/secrets/kubernetes/kube-scheduler/kubeconfig
     defaultkubeconfig: /etc/kubernetes/scheduler.conf
 
@@ -84,6 +85,7 @@ master:
     kubeconfig:
       - /etc/kubernetes/controller-manager.conf
       - /var/lib/kube-controller-manager/kubeconfig
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
       - /system/secrets/kubernetes/kube-controller-manager/kubeconfig
     defaultkubeconfig: /etc/kubernetes/controller-manager.conf
 

--- a/cfg/rke2-cis-1.23/master.yaml
+++ b/cfg/rke2-cis-1.23/master.yaml
@@ -223,7 +223,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "644"
@@ -239,7 +239,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -255,7 +255,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "644"
@@ -271,7 +271,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -282,7 +282,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown root:root /var/lib/rancher/rke2/server/cred/controller.kubeconfig
+          chown root:root $controllermanagerkubeconfig
         scored: true
 
       - id: 1.1.19

--- a/cfg/rke2-cis-1.24/master.yaml
+++ b/cfg/rke2-cis-1.24/master.yaml
@@ -229,7 +229,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "600"
@@ -245,7 +245,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -261,7 +261,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "600"
@@ -277,7 +277,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -288,7 +288,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown root:root /var/lib/rancher/rke2/server/cred/controller.kubeconfig
+          chown root:root $controllermanagerkubeconfig
         scored: true
 
       - id: 1.1.19

--- a/cfg/rke2-cis-1.7/master.yaml
+++ b/cfg/rke2-cis-1.7/master.yaml
@@ -239,7 +239,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -271,7 +271,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -282,7 +282,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown root:root /var/lib/rancher/rke2/server/cred/controller.kubeconfig
+          chown root:root $controllermanagerkubeconfig
         scored: true
 
       - id: 1.1.19


### PR DESCRIPTION
Resolves #1843.

This PR adds pathes to `schedulerkubeconfig` and `controllermanagerkubeconfig` to fix the failures. And replace hard coded values with variables.