### PR TITLE
chore(ci): bump up golangci-lint version to v1.64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.64
           args: --verbose --timeout 2m
   unit:
     name: Unit tests


### PR DESCRIPTION
This PR bumps up  golangci-lint version to v1.64 to fix unexpected linter errors:
* https://github.com/aquasecurity/kube-bench/actions/runs/14180473461?pr=1848
* https://github.com/aquasecurity/kube-bench/actions/runs/14180461348/job/39725198642?pr=1847