### PR TITLE
fix: update kubectl to v1.33.0

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ uname := $(shell uname -s)
 BUILDX_PLATFORM ?= linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/s390x
 DOCKER_ORGS ?= aquasec public.ecr.aws/aquasecurity
 GOARCH ?= $@
-KUBECTL_VERSION ?= 1.33.0-alpha.3
+KUBECTL_VERSION ?= 1.33.0
 ARCH ?= $(shell go env GOARCH)
 
 ifneq ($(findstring Microsoft,$(shell uname -r)),)


### PR DESCRIPTION
This PR fixes Go vulnerabilities inside `kubectl`.

before:
```sh
trivy i aquasec/kube-bench:v0.10.5
2025-04-24T12:47:39+06:00       INFO    [vuln] Vulnerability scanning is enabled
2025-04-24T12:47:39+06:00       INFO    [secret] Secret scanning is enabled
2025-04-24T12:47:39+06:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-04-24T12:47:39+06:00       INFO    [secret] Please see also https://trivy.dev/v0.61/docs/scanner/secret#recommendation for faster secret detection
2025-04-24T12:47:40+06:00       INFO    Detected OS     family="alpine" version="3.21.3"
2025-04-24T12:47:40+06:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.21" repository="3.21" pkg_num=29
2025-04-24T12:47:40+06:00       INFO    Number of language-specific files       num=2
2025-04-24T12:47:40+06:00       INFO    [gobinary] Detecting vulnerabilities...
2025-04-24T12:47:40+06:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/v0.61/docs/scanner/vulnerability#severity-selection for details.

Report Summary

┌────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                   Target                   │   Type   │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ aquasec/kube-bench:v0.10.5 (alpine 3.21.3) │  alpine  │        0        │    -    │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kube-bench                   │ gobinary │        0        │    -    │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kubectl                      │ gobinary │        3        │    -    │
└────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


usr/local/bin/kubectl (gobinary)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2025-22870 │ MEDIUM   │ fixed  │ v0.33.0           │ 0.36.0         │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:  │
│                  │                │          │        │                   │                │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net │
│                  │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22870                │
│                  ├────────────────┤          │        │                   ├────────────────┼───────────────────────────────────────────────────────────┤
│                  │ CVE-2025-22872 │          │        │                   │ 0.38.0         │ golang.org/x/net/html: Incorrect Neutralization of Input  │
│                  │                │          │        │                   │                │ During Web Page Generation in x/net in...                 │
│                  │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22872                │
├──────────────────┼────────────────┤          │        ├───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib           │ CVE-2025-22871 │          │        │ v1.24.0           │ 1.23.8, 1.24.2 │ net/http: Request smuggling due to acceptance of invalid  │
│                  │                │          │        │                   │                │ chunked data in net/http...                               │
│                  │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22871                │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘
```
after:
```sh
 trivy i aquasec/kube-bench:5feae8a
2025-04-24T13:01:36+06:00       INFO    [vuln] Vulnerability scanning is enabled
2025-04-24T13:01:36+06:00       INFO    [secret] Secret scanning is enabled
2025-04-24T13:01:36+06:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-04-24T13:01:36+06:00       INFO    [secret] Please see also https://trivy.dev/v0.61/docs/scanner/secret#recommendation for faster secret detection
2025-04-24T13:01:37+06:00       INFO    Detected OS     family="alpine" version="3.21.3"
2025-04-24T13:01:37+06:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.21" repository="3.21" pkg_num=29
2025-04-24T13:01:37+06:00       INFO    Number of language-specific files       num=2
2025-04-24T13:01:37+06:00       INFO    [gobinary] Detecting vulnerabilities...

Report Summary

┌────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                   Target                   │   Type   │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ aquasec/kube-bench:5feae8a (alpine 3.21.3) │  alpine  │        0        │    -    │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kube-bench                   │ gobinary │        0        │    -    │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kubectl                      │ gobinary │        0        │    -    │
└────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```