### PR TITLE
fix(rke1- audit): improve of etcd, controller, and scheduler audits

### DIFF
--- a/cfg/rke-cis-1.7/master.yaml
+++ b/cfg/rke-cis-1.7/master.yaml
@@ -171,14 +171,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/etcd
+        audit: '/bin/sh -c "if test -e /var/lib/etcd; then stat -c %a /var/lib/etcd; else echo \"Directory not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: "700"
-              compare:
-                op: eq
-                value: "700"
-              set: true
+            - flag: "Directory not found"
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -947,14 +945,16 @@ groups:
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        audit: '/bin/sh -c "if test -e $controllermanagerbin; then /bin/ps -ef | grep $controllermanagerbin | grep -v grep; else echo \"Controller manager binary not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
               set: true
+            - flag: "Controller manager binary not found"
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
@@ -980,14 +980,16 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        audit: '/bin/sh -c "if test -e $schedulerbin; then /bin/ps -ef | grep $schedulerbin | grep -v grep; else echo \"Scheduler binary not found\"; fi"'
         tests:
+          bin_op: or
           test_items:
             - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"
               set: true
+            - flag: "Scheduler binary not found"
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf
           on the control plane node and ensure the correct value for the --bind-address parameter


### PR DESCRIPTION
- Updated 1.1.11 to wrap etcd data directory stat in a conditional check.
- Updated 1.3.7 and 1.4.2 to conditionally check if the controller manager and scheduler binaries exist before running ps/grep.