### PR TITLE
chore: bunp up Go version to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/kube-bench
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.4


### PR DESCRIPTION
this PR fixes some vulnerabilities in Go stdlib.

Before:
```sh
Report Summary

┌────────┬──────────┬─────────────────┬─────────┐
│ Target │   Type   │ Vulnerabilities │ Secrets │
├────────┼──────────┼─────────────────┼─────────┤
│ kb     │ gobinary │        3        │    -    │
└────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


kb (gobinary)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy         │
│         │                │          │        │                   │                 │ validation in crypto/x509                                    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-0913  │ MEDIUM   │        │                   │ 1.23.10, 1.24.4 │ Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows │
│         │                │          │        │                   │                 │ in os in syscall...                                          │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-0913                    │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-4673  │          │        │                   │                 │ Proxy-Authorization and Proxy-Authenticate headers persisted │
│         │                │          │        │                   │                 │ on cross- ...                                                │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-4673                    │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```
After:
```sh

Report Summary

┌────────┬──────────┬─────────────────┬─────────┐
│ Target │   Type   │ Vulnerabilities │ Secrets │
├────────┼──────────┼─────────────────┼─────────┤
│ kb     │ gobinary │        0        │    -    │
└────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```