### PR TITLE
chore: use kubectl 1.34.0-alpha.1

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ uname := $(shell uname -s)
 BUILDX_PLATFORM ?= linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/s390x
 DOCKER_ORGS ?= aquasec public.ecr.aws/aquasecurity
 GOARCH ?= $@
-KUBECTL_VERSION ?= 1.33.0
+KUBECTL_VERSION ?= 1.34.0-alpha.1
 ARCH ?= $(shell go env GOARCH)
 
 ifneq ($(findstring Microsoft,$(shell uname -r)),)


### PR DESCRIPTION
This PR uses kubectl 1.34.0-alpha.1 to fix known vulnerabilities in Go stdlib.

Before:
```sh

Report Summary

┌──────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                        Target                        │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/aquasec/kube-bench:98aa7bb (alpine 3.22.0) │  alpine  │        0        │    -    │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kube-bench                             │ gobinary │        0        │    -    │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kubectl                                │ gobinary │        3        │    -    │
└──────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


usr/local/bin/kubectl (gobinary)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22874 │ HIGH     │ fixed  │ v1.24.2           │ 1.24.4          │ crypto/x509: Usage of ExtKeyUsageAny disables policy         │
│         │                │          │        │                   │                 │ validation in crypto/x509                                    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-22874                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-0913  │ MEDIUM   │        │                   │ 1.23.10, 1.24.4 │ Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows │
│         │                │          │        │                   │                 │ in os in syscall...                                          │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-0913                    │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-4673  │          │        │                   │                 │ Proxy-Authorization and Proxy-Authenticate headers persisted │
│         │                │          │        │                   │                 │ on cross- ...                                                │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-4673                    │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```
After:
```sh

Report Summary

┌──────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                        Target                        │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ docker.io/aquasec/kube-bench:98aa7bb (alpine 3.22.0) │  alpine  │        0        │    -    │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kube-bench                             │ gobinary │        0        │    -    │
├──────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kubectl                                │ gobinary │        0        │    -    │
└──────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘

```