### PR TITLE
Update golangci lint to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.5.0
           args: --verbose --timeout 2m
   unit:
     name: Unit tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,28 @@
----
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - gocyclo
-    - gofmt
-    - goimports
     - govet
     - misspell
-    - typecheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
This updates the golangci-lint config to use the new v2 schema. It also bumps the version of golangci-lint used in the build workflow to use the latest v2 release.