### PR TITLE
Move helper script to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,14 @@ RUN apk add jq
 # Add bash for running helper scripts
 RUN apk add bash
 
-ENV PATH=$PATH:/usr/local/mount-from-host/bin:/go/bin
+ENV PATH=$PATH:/usr/local/mount-from-host/bin
 
 COPY --from=build /go/bin/kube-bench /usr/local/bin/kube-bench
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY entrypoint.sh .
 COPY cfg/ cfg/
-COPY helper_scripts/check_files_owner_in_dir.sh /go/bin/
-RUN chmod a+x /go/bin/check_files_owner_in_dir.sh
+COPY helper_scripts/check_files_owner_in_dir.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/check_files_owner_in_dir.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["install"]
 

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -42,7 +42,8 @@ COPY --from=build /go/bin/kube-bench /usr/local/bin/kube-bench
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY entrypoint.sh .
 COPY cfg/ cfg/
-COPY helper_scripts/check_files_owner_in_dir.sh /go/bin
+COPY helper_scripts/check_files_owner_in_dir.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/check_files_owner_in_dir.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["install"]
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -42,7 +42,8 @@ COPY --from=build /go/bin/kube-bench /usr/local/bin/kube-bench
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY entrypoint.sh .
 COPY cfg/ cfg/
-COPY helper_scripts/check_files_owner_in_dir.sh /go/bin
+COPY helper_scripts/check_files_owner_in_dir.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/check_files_owner_in_dir.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["install"]
 


### PR DESCRIPTION
Small change to "right-place" the helper scripts into /usr/local/bin, which is already in `$PATH`.

This should have no functional change - it just popped up on a security scan that thought it was strange that /go/bin was in `$PATH` for the root user. Since this is the only thing there, and it's not actually a built go bin, it seemed reasonable to place it in /usr/local/bin instead.

This PR also addresses what seems to be an incomplete fix in #1755 in that it only seemed to address one of the three Dockerfiles in the repo.