### PR TITLE
Kube Bench selects cis-1.10, 1.1, or 1.12 for K3s 

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -606,7 +606,7 @@ func k3sBenchmark(version string) string {
 	case "1.25", "1.26", "1.27":
 		return "k3s-cis-1.7"
 	default:
-		return ""
+		return "k3s-cis-1.8"
 	}
 }
 

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -777,6 +777,27 @@ func Test_getPlatformBenchmarkVersion(t *testing.T) {
 			want: "k3s-cis-1.7",
 		},
 		{
+			name: "k3s 1.28",
+			args: args{
+				platform: Platform{Name: "k3s", Version: "1.28"},
+			},
+			want: "k3s-cis-1.8",
+		},
+		{
+			name: "k3s 1.34",
+			args: args{
+				platform: Platform{Name: "k3s", Version: "1.34"},
+			},
+			want: "k3s-cis-1.8",
+		},
+		{
+			name: "k3s future",
+			args: args{
+				platform: Platform{Name: "k3s", Version: "1.40"},
+			},
+			want: "k3s-cis-1.8",
+		},
+		{
 			name: "rancher1",
 			args: args{
 				platform: Platform{Name: "rancher", Version: "1.27"},


### PR DESCRIPTION
Kube Bench selects cis-1.10, 1.1, or 1.12 for K3s depending on its version (v0.10.0, v0.14, v0.15.0) instead of k3s-cis-1.8 tests