### PR TITLE
ci: free disk space

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,16 @@ jobs:
     name: Publish
     runs-on: ubuntu-2404-2core
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null
+          df -h
       - name: Check Out Repo
         uses: actions/checkout@v6
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,17 @@ jobs:
     name: Release
     runs-on: ubuntu-2404-2core
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force > /dev/null
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description 
This PR removes .NET, Android SDK, GHC, Boost, CodeQL, and unused Docker images. It should fixe disk space errors during releasing and publishing: https://github.com/aquasecurity/kube-bench/actions/runs/25168801390/job/73782120898

The same way we use for vuln-list-redhat https://github.com/aquasecurity/vuln-list-update/pull/435.