### PR TITLE
Add support for space separator when auditing CLI options

### DIFF
--- a/check/test.go
+++ b/check/test.go
@@ -126,20 +126,35 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 		// Expects flags in the form;
 		// --flag=somevalue
 		// flag: somevalue
+		// flag somevalue
 		// --flag
 		// somevalue
 		// DOESN'T COVER - use pathTestItem implementation of findValue() for this
 		// flag:
 		//	 - wehbook
-		pttn := `(` + t.Flag + `)(=|: *)*([^\s]*) *`
+
+		// Match the flag of interest:
+		pttn1 := `(` + t.Flag + `)`
+		// Consume any number of `=` or `:` separators:
+		pttn2 := `[=:]*`
+		// Consume any whitespace after separator:
+		pttn3 := `\s*`
+		// Match any number of non-whitespace characters as the flag value:
+		pttn4 := `(\S*)`
+		pttn := pttn1 + pttn2 + pttn3 + pttn4
+
 		flagRe := regexp.MustCompile(pttn)
 		vals := flagRe.FindStringSubmatch(s)
 
 		if len(vals) > 0 {
-			if vals[3] != "" {
-				value = vals[3]
+			// If there is a match
+			if vals[2] != "" && !strings.HasPrefix(vals[2], "--") {
+				// If the "flag value" capture group matched text and the match
+				// does not look like another flag
+				value = vals[2]
 			} else {
-				// --bool-flag
+				// If there is no "flag value" or it is another flag,
+				// then this is a bool flag
 				if strings.HasPrefix(t.Flag, "--") {
 					value = "true"
 				} else {

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -71,6 +71,20 @@ func TestTestExecute(t *testing.T) {
 			expectedTestResult: "'--insecure-port' is equal to '0'",
 		},
 		{
+			// space separator with -- prefix
+			check:              controls.Groups[0].Checks[2],
+			str:                "2:45 ../kubernetes/kube-apiserver --insecure-port 0 --anonymous-auth",
+			strConfig:          "",
+			expectedTestResult: "'--insecure-port' is equal to '0'",
+		},
+		{
+			// space separator with -- prefix, value at end of string
+			check:              controls.Groups[0].Checks[3],
+			str:                "2:45 ../kubernetes/kube-apiserver --secure-port=0 --audit-log-maxage 40",
+			strConfig:          "",
+			expectedTestResult: "'--audit-log-maxage' is greater or equal to 30",
+		},
+		{
 			check:              controls.Groups[0].Checks[3],
 			str:                "2:45 ../kubernetes/kube-apiserver --secure-port=0 --audit-log-maxage=40 --option",
 			strConfig:          "",
@@ -89,6 +103,13 @@ func TestTestExecute(t *testing.T) {
 			expectedTestResult: "'--admission-control' does not have 'AlwaysAdmit'",
 		},
 		{
+			// space separator preserves comma-separated value
+			check:              controls.Groups[0].Checks[5],
+			str:                "2:45 ../kubernetes/kube-apiserver --option --admission-control WebHook,RBAC ---audit-log-maxage=40",
+			strConfig:          "",
+			expectedTestResult: "'--admission-control' does not have 'AlwaysAdmit'",
+		},
+		{
 			check:              controls.Groups[0].Checks[6],
 			str:                "2:45 .. --kubelet-clientkey=foo --kubelet-client-certificate=bar --admission-control=Webhook,RBAC",
 			strConfig:          "",
@@ -103,6 +124,20 @@ func TestTestExecute(t *testing.T) {
 		{
 			check:              controls.Groups[0].Checks[8],
 			str:                "permissions=SomeValue",
+			strConfig:          "",
+			expectedTestResult: "'permissions' is equal to 'SomeValue'",
+		},
+		{
+			// space separator with bare flag (no -- prefix)
+			check:              controls.Groups[0].Checks[8],
+			str:                "permissions SomeValue",
+			strConfig:          "",
+			expectedTestResult: "'permissions' is equal to 'SomeValue'",
+		},
+		{
+			// space separator with bare flag, value at end of string
+			check:              controls.Groups[0].Checks[8],
+			str:                "permissions SomeValue someFlag someOtherValue",
 			strConfig:          "",
 			expectedTestResult: "'permissions' is equal to 'SomeValue'",
 		},


### PR DESCRIPTION
Ref issue: https://github.com/aquasecurity/kube-bench/issues/2095

This change adds support for auditing `--flag value` and `flag value` style command line options.

Previously, CLI options with a space as separator fell through to the bool-flag branch, detecting "true" instead of the actual value.

The key fix is to the separator capture group: `=` and `:` are now optional.

To improve readability, capture groups in `pttn` are now defined separately and later concatenated, with comments providing explanations for their purpose.

Additionally:
- The separator match is not a capture group anymore: its result was unused
- Replaced `^\s` with the equivalent `\S`
- Removed unnecessary trailing ` *`

New test cases verify the change.