### PR TITLE
fix(cis-1.6): automate check 1.2.26 for --request-timeout

### DIFF
--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -1004,7 +1004,7 @@ groups:
         tests:
           bin_op: or
           test_items:
-            - flag: "--bind-address"h
+            - flag: "--bind-address"
               compare:
                 op: eq
                 value: "127.0.0.1"

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -727,8 +727,8 @@ groups:
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
-                  test_items:
-                              - flag: "--request-timeout"
+          test_items:
+            - flag: "--request-timeout"
         remediation: |
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.

--- a/cfg/cis-1.6/master.yaml
+++ b/cfg/cis-1.6/master.yaml
@@ -726,7 +726,9 @@ groups:
       - id: 1.2.26
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
+        tests:
+                  test_items:
+                              - flag: "--request-timeout"
         remediation: |
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.
@@ -1002,7 +1004,7 @@ groups:
         tests:
           bin_op: or
           test_items:
-            - flag: "--bind-address"
+            - flag: "--bind-address"h
               compare:
                 op: eq
                 value: "127.0.0.1"


### PR DESCRIPTION
## Problem

Check 1.2.26 in `cfg/cis-1.6/master.yaml` is marked as `type: manual`, which causes kube-bench to always return `[WARN]` for this check — even when `--request-timeout` is correctly set on the kube-apiserver.

This is a bug because the check description says "(Automated)" but it behaves as manual.

## Fix

Remove the `type: manual` field and replace it with a proper `tests` block that checks for the presence of the `--request-timeout` flag. This approach is consistent with how similar checks are implemented in the same file (e.g., check 1.2.28 for `--service-account-key-file`).

With this fix, kube-bench will return:
- `[PASS]` when `--request-timeout` is set on the kube-apiserver
- - `[FAIL]` when it is not set
## Related Issue

Fixes #1245