### PR TITLE
refactor: optimize layer structure of Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,27 +11,28 @@ RUN make build && cp kube-bench /go/bin/kube-bench
 
 FROM alpine:3.23.4 AS run
 WORKDIR /opt/kube-bench/
+
 # add GNU ps for -C, -o cmd, --no-headers support and add findutils to get GNU xargs
 # https://github.com/aquasecurity/kube-bench/issues/109
 # https://github.com/aquasecurity/kube-bench/issues/1656
-RUN apk --no-cache add procps findutils
 
 # Upgrading apk-tools to remediate CVE-2021-36159 - https://snyk.io/vuln/SNYK-ALPINE314-APKTOOLS-1533752
-# https://github.com/aquasecurity/kube-bench/issues/943
-RUN apk --no-cache upgrade apk-tools
+# https://github.com/aquasecurity/kube-bench/issues/943
 
 # Openssl is used by OpenShift tests
 # https://github.com/aquasecurity/kube-bench/issues/535
 # Ensuring that we update/upgrade before installing openssl, to mitigate CVE-2021-3711 and CVE-2021-3712
-RUN apk update && apk upgrade && apk --no-cache add openssl
-
-# Add glibc for running oc command 
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN apk add gcompat
-RUN apk add jq
-
+# Add glibc for running oc command
 # Add bash for running helper scripts
-RUN apk add --no-cache bash kubectl
+RUN apk --no-cache upgrade \
+    && apk --no-cache add \
+        bash \
+        findutils \
+        gcompat \
+        jq \
+        kubectl \
+        openssl \
+        procps
 
 ENV PATH=$PATH:/usr/local/mount-from-host/bin:/go/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,11 @@ RUN make build && cp kube-bench /go/bin/kube-bench
 FROM alpine:3.23.4 AS run
 WORKDIR /opt/kube-bench/
 
-# add GNU ps for -C, -o cmd, --no-headers support and add findutils to get GNU xargs
-# https://github.com/aquasecurity/kube-bench/issues/109
-# https://github.com/aquasecurity/kube-bench/issues/1656
-
-# Upgrading apk-tools to remediate CVE-2021-36159 - https://snyk.io/vuln/SNYK-ALPINE314-APKTOOLS-1533752
-# https://github.com/aquasecurity/kube-bench/issues/943
-
-# Openssl is used by OpenShift tests
-# https://github.com/aquasecurity/kube-bench/issues/535
-# Ensuring that we update/upgrade before installing openssl, to mitigate CVE-2021-3711 and CVE-2021-3712
-# Add glibc for running oc command
-# Add bash for running helper scripts
+# procps adds GNU ps for -C, -o cmd, --no-headers support: https://github.com/aquasecurity/kube-bench/pull/115/
+# findutils is used to get GNU xargs: https://github.com/aquasecurity/kube-bench/pull/1657
+# Openssl is used by OpenShift tests: https://github.com/aquasecurity/kube-bench/pull/537
+# glibc is used for running oc command
+# bash is used for running helper scripts
 RUN apk --no-cache upgrade \
     && apk --no-cache add \
         bash \

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -14,13 +14,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS run
 ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
-  && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
   && yum update -y \
-  && yum install -y glibc \
-  && yum update -y glibc \
-  && yum install -y procps \
-  && yum update -y procps \
-  && yum install jq -y \
+  && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \
        'enabled=1' 'gpgcheck=1' \

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -15,6 +15,7 @@ ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
   && yum update -y \
+  && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
   && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \

--- a/Dockerfile.fips.ubi
+++ b/Dockerfile.fips.ubi
@@ -14,8 +14,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS run
 ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
-  && yum update -y \
   && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
+  && yum update -y \
   && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -14,13 +14,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS run
 ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
-  && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
   && yum update -y \
-  && yum install -y glibc \
-  && yum update -y glibc \
-  && yum install -y procps \
-  && yum update -y procps \
-  && yum install jq -y \
+  && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \
        'enabled=1' 'gpgcheck=1' \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -15,6 +15,7 @@ ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
   && yum update -y \
+  && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
   && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -14,8 +14,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS run
 ARG K8S_PKGS_VERSION=1.34
 
 RUN microdnf install -y yum findutils openssl \
-  && yum update -y \
   && yum -y update-minimal --security --sec-severity=Moderate --sec-severity=Important --sec-severity=Critical \
+  && yum update -y \
   && yum install -y glibc jq procps \
   && printf '%s\n' '[kubernetes]' 'name=Kubernetes' \
        "baseurl=https://pkgs.k8s.io/core:/stable:/v${K8S_PKGS_VERSION}/rpm/" \


### PR DESCRIPTION
Reduce intermediate layer count and build time by merging redundant
  package manager calls in all three Dockerfiles.

  **Dockerfile (Alpine)**

  Collapsed 7 separate `RUN` instructions into one:
  - Single `apk --no-cache upgrade` replaces the fragmented
    `apk --no-cache upgrade apk-tools` + `apk update && apk upgrade` sequence
  - All `apk add` calls merged into a single invocation
  - Removed dead `wget` fetching `sgerrand.rsa.pub` — that key is for
    installing `glibc` from the sgerrand third-party repo; `gcompat` (the
    package actually used) is in Alpine's official repos and never needed it

  **Dockerfile.ubi / Dockerfile.fips.ubi**

  Streamlined the single `RUN` block:
  - Removed `yum -y update-minimal --security ...` — redundant when
    immediately followed by `yum update -y`, which is a strict superset
  - Merged three separate `yum install` calls (`glibc`, `procps`, `jq`)
    into one
  - Removed `yum update -y glibc` and `yum update -y procps` — redundant
    right after a full `yum update -y`

  No functional changes; installed packages and their versions are unchanged.