### PR TITLE
ci: pin GitHub Actions to immutable commit hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Setup Kubernetes cluster (KIND)
-        uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1  # v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
           version: v2.11.4
           args: --verbose --timeout 2m
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: Run unit tests
         run: make tests
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
         with:
           file: ./coverage.txt
   e2e:
@@ -56,13 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       - name: Setup Kubernetes cluster (KIND)
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1  # v0.6.2
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}
@@ -75,7 +75,7 @@ jobs:
         run: |
           make integration-test
       - name: Compare output with expected output
-        uses: GuillaumeFalourd/diff-action@v1
+        uses: GuillaumeFalourd/diff-action@b341507d1da990caceac1b3b31b8f55eebaa2e99  # v1
         with:
           first_file_path: ./test.data
           second_file_path: integration/testdata/Expected_output.data
@@ -86,7 +86,7 @@ jobs:
     needs: [e2e, unit]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
@@ -94,7 +94,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Dry-run release snapshot
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           distribution: goreleaser
           version: v1.7.0

--- a/.github/workflows/mkdocs-deploy.yaml
+++ b/.github/workflows/mkdocs-deploy.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.x
       - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,33 +26,33 @@ jobs:
           sudo docker image prune --all --force > /dev/null
           df -h
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       - name: Cache Docker layers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildxarch-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildxarch-
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to ECR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: public.ecr.aws
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
       - name: Get version
         id: get_version
-        uses: crazy-max/ghaction-docker-meta@v5
+        uses: crazy-max/ghaction-docker-meta@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REP }}
           tag-semver: |
@@ -64,7 +64,7 @@ jobs:
           echo "K8S_PKGS_VERSION=$(grep -oP '^K8S_PKGS_VERSION\s*\?=\s*\K.*' makefile)" >> $GITHUB_ENV
       - name: Build and push - Docker/ECR
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push ubi image - Docker/ECR
         id: docker_build_ubi
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build and push fips ubi image - Docker/ECR
         id: docker_build_fips_ubi
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
@@ -35,7 +35,7 @@ jobs:
       - name: Run unit tests
         run: make tests
       - name: Setup Kubernetes cluster (KIND)
-        uses: engineerd/setup-kind@v0.6.2
+        uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1  # v0.6.2
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}
@@ -48,13 +48,13 @@ jobs:
         run: |
           make integration-test
       - name: Compare output with expected output
-        uses: GuillaumeFalourd/diff-action@v1
+        uses: GuillaumeFalourd/diff-action@b341507d1da990caceac1b3b31b8f55eebaa2e99  # v1
         with:
           first_file_path: ./test.data
           second_file_path: integration/testdata/Expected_output.data
           expected_result: PASSED
       - name: Release
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           distribution: goreleaser
           version: v1.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run unit tests
         run: make tests
       - name: Setup Kubernetes cluster (KIND)
-        uses: engineerd/setup-kind@71e45b960fc8dd50b4aeabf6eb6ef2ca0920b4c1  # v0.6.2
+        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}


### PR DESCRIPTION
## Description
GitHub Actions referenced by mutable version tags (e.g. @v4, @v7) can be silently altered by a tag force-push, creating a supply chain attack vector. This change pins all action references to their exact commit SHA, with the original tag retained as a comment for readability.

All workflow files have been updated:
- actions/checkout @v6 to @de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2): https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
- actions/setup-python @v6 to @a309ff8b426b58ec0e2a45f0f869d46889d02405 (v6.2.0): https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405
- actions/cache@v5 to @27d5ce7f107fe9357f9df03efb73ab90386fccae (v5.0.5): https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae
- ibiqlik/action-yamllint@v3 to @2576378a8e339169678f9939646ee3ee325e845c (v3.1.1): https://github.com/ibiqlik/action-yamllint/commit/2576378a8e339169678f9939646ee3ee325e845c
- golangci/golangci-lint-action@v8 to @4afd733a84b1f43292c63897423277bb7f4313a9 (v8.0.0): https://github.com/golangci/golangci-lint-action/commit/4afd733a84b1f43292c63897423277bb7f4313a9
- codecov/codecov-action@v5 to @75cd11691c0faa626561e295848008c8a7dddffe (v5.5.4): https://github.com/codecov/codecov-action/commit/75cd11691c0faa626561e295848008c8a7dddffe
- engineerd/setup-kind@v0.6.2 to @ecfad61750951586a9ef973db567df1d28671bdc (v0.6.2): https://github.com/engineerd/setup-kind/commit/ecfad61750951586a9ef973db567df1d28671bdc
- GuillaumeFalourd/diff-action@v1 to @b341507d1da990caceac1b3b31b8f55eebaa2e99 (v1): https://github.com/GuillaumeFalourd/diff-action/commit/b341507d1da990caceac1b3b31b8f55eebaa2e99
- goreleaser/goreleaser-action: @v7 to @5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 (v7.2.2): https://github.com/goreleaser/goreleaser-action/commit/5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
- docker/setup-qemu-action@v4 to @ce360397dd3f832beb865e1373c09c0e9f86d70a (v4.0.0): https://github.com/docker/setup-qemu-action/commit/ce360397dd3f832beb865e1373c09c0e9f86d70a
- docker/setup-buildx-action@v4 to @4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd (v4.0.0): https://github.com/docker/setup-buildx-action/commit/4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
- docker/login-action@v4 to @4907a6ddec9925e35a0a9e82d7399ccc52663121 (v4.1.0): https://github.com/docker/login-action/commit/4907a6ddec9925e35a0a9e82d7399ccc52663121
- docker/build-push-action@v7 to @f9f3042f7e2789586610d6e8b85c8f03e5195baf (v7.2.0): https://github.com/docker/build-push-action/commit/f9f3042f7e2789586610d6e8b85c8f03e5195baf
- crazy-max/ghaction-docker-meta@v5 to @c299e40c65443455700f0fdfc63efafe5b349051 (v5.10.0): https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051