### PR TITLE
fix(cfg): don't fail CNI file checks when host-local IPAM dir is absent

### DIFF
--- a/cfg/k3s-cis-1.7/master.yaml
+++ b/cfg/k3s-cis-1.7/master.yaml
@@ -120,7 +120,12 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
-        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          else
+            echo "permissions=600"
+          fi
         use_multiple_values: true
         tests:
           test_items:
@@ -137,7 +142,12 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
-        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          else
+            echo "root:root"
+          fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/k3s-cis-1.8/master.yaml
+++ b/cfg/k3s-cis-1.8/master.yaml
@@ -120,7 +120,12 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          else
+            echo "permissions=600"
+          fi
         use_multiple_values: true
         tests:
           test_items:
@@ -137,7 +142,12 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
-        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          else
+            echo "root:root"
+          fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/k3s-cis-1.9/master.yaml
+++ b/cfg/k3s-cis-1.9/master.yaml
@@ -120,7 +120,12 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          else
+            echo "permissions=600"
+          fi
         use_multiple_values: true
         tests:
           test_items:
@@ -137,7 +142,12 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
-        audit: find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        audit: |
+          if [ -d /var/lib/cni/networks ] && [ -n "$(find /var/lib/cni/networks -type f ! -name lock 2>/dev/null)" ]; then
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          else
+            echo "root:root"
+          fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke-cis-1.23/master.yaml
+++ b/cfg/rke-cis-1.23/master.yaml
@@ -121,8 +121,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=644"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -138,8 +141,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke-cis-1.24/master.yaml
+++ b/cfg/rke-cis-1.24/master.yaml
@@ -124,8 +124,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=600"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -141,8 +144,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke-cis-1.7/master.yaml
+++ b/cfg/rke-cis-1.7/master.yaml
@@ -140,8 +140,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=600"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -157,8 +160,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke2-cis-1.23/master.yaml
+++ b/cfg/rke2-cis-1.23/master.yaml
@@ -148,8 +148,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=644"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -165,8 +168,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke2-cis-1.7/master.yaml
+++ b/cfg/rke2-cis-1.7/master.yaml
@@ -151,8 +151,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=600"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -168,8 +171,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:

--- a/cfg/rke2-cis-1.8/master.yaml
+++ b/cfg/rke2-cis-1.8/master.yaml
@@ -153,8 +153,11 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          cni_perms=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c permissions=%a
+          )
+          if [ -n "$cni_perms" ]; then echo "$cni_perms"; else echo "permissions=600"; fi
         use_multiple_values: true
         tests:
           test_items:
@@ -170,8 +173,11 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+          cni_owners=$(
+            ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+            find /var/lib/cni/networks -type f ! -name lock 2>/dev/null | xargs --no-run-if-empty stat -c %U:%G
+          )
+          if [ -n "$cni_owners" ]; then echo "$cni_owners"; else echo "root:root"; fi
         use_multiple_values: true
         tests:
           test_items:


### PR DESCRIPTION
## What

Checks 1.1.9 and 1.1.10 audit CNI file permissions/ownership by running `find /var/lib/cni/networks`. That directory is the host-local IPAM state store, populated only by CNIs that use host-local IPAM (e.g. the flannel backend that ships as the k3s default). Under a CNI with its own IPAM (Cilium, Calico, ...) the directory does not exist, `find` returns nothing, and an empty `use_multiple_values` audit is scored as FAIL (Automated profiles) or WARN (Manual profiles) — a false positive unrelated to any real permission or ownership problem. See #2119.

## Change

Rewrite the 1.1.9/1.1.10 audit so an absent or empty `/var/lib/cni/networks` yields a passing sentinel value (`permissions=<mode>` / `root:root`) instead of an empty result. When host-local IPAM files do exist, their real permissions and ownership are still evaluated, so genuine issues continue to fail. The host-local `lock` file (created 0750) is also excluded from the permission check so it no longer trips the 600 bitmask (previously only 1.1.9 in the k3s profiles excluded it).

Profiles touched (both 1.1.9 and 1.1.10):

- `k3s-cis-1.7`, `k3s-cis-1.8`, `k3s-cis-1.9` (single-command audit)
- `rke-cis-1.7`, `rke-cis-1.23`, `rke-cis-1.24`
- `rke2-cis-1.7`, `rke2-cis-1.8`, `rke2-cis-1.23` (two-command audit)

Not touched, by design:

- `k3s-cis-1.23` / `k3s-cis-1.24` already mark these checks `type: skip`.
- `rke2-cis-1.24` 1.1.10 already guards with an `else echo "File not found"` branch and `bin_op: or`.
- The generic `cis-*` profiles keep these checks Manual (WARN) and stay aligned with upstream CIS; I left them as-is to avoid changing the CIS baseline. Happy to extend the same tolerance there if you prefer uniform coverage.

## Validation

Audit logic tested in isolation for both audit shapes: absent directory → passing sentinel; a real 600 file → `permissions=600`; a real 644 file → `permissions=644` (the failing value still surfaces); a 0750 `lock` file → excluded.

End-to-end on a k3s node running Cilium (`/var/lib/cni/networks` absent), same binary, config-dir difference only:

```
# before (released cfg)
[FAIL] 1.1.9  ...
[FAIL] 1.1.10 ...
# after (this change)
[PASS] 1.1.9  ...
[PASS] 1.1.10 ...
```

## Alternative considered

Aligning the k3s/rke/rke2 profiles to `scored: false` (WARN), matching the generic `cis-*` profiles, would hide the hard FAIL but also stop flagging real permission/ownership problems on clusters that do use host-local IPAM. The audit-tolerance approach keeps the checks Automated and meaningful for those clusters while removing the false positive on the others, so I chose it over down-scoring. A third option — the `type: skip` used by `k3s-cis-1.23/1.24` — disables the check even where it is valid; audit-tolerance is a strict improvement over that and could replace those skips in a follow-up.

Fixes #2119
