### PR TITLE
Migrate yaml from gopkg.in/yaml.v2 to go.yaml.in/yaml/v3

### DIFF
--- a/check/controls.go
+++ b/check/controls.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v3"
 )
 
 const cfgDir = "../cfg/"
@@ -95,7 +95,6 @@ groups:
 		// then
 		assert.EqualError(t, err, "failed to unmarshal YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `BOOM` into check.Controls")
 	})
-
 }
 
 func TestControls_RunChecks_SkippedCmd(t *testing.T) {
@@ -204,7 +203,7 @@ groups:
 		var runAll Predicate = func(group *Group, c *Check) bool {
 			return true
 		}
-		var emptySkipList = make(map[string]bool, 0)
+		emptySkipList := make(map[string]bool, 0)
 		// when
 		controls.RunChecks(runner, runAll, emptySkipList)
 		// then
@@ -336,7 +335,8 @@ func TestControls_JUnitIncludesJSON(t *testing.T) {
 					}
 
 					if out.TestCases[iGroup*iCheck+iCheck].SystemOut != string(jsonBytes) {
-						t.Errorf("Expected\n\t%v\n\tbut got\n\t%v",
+						t.Errorf(
+							"Expected\n\t%v\n\tbut got\n\t%v",
 							out.TestCases[iGroup*iCheck+iCheck].SystemOut,
 							string(jsonBytes),
 						)
@@ -345,7 +345,8 @@ func TestControls_JUnitIncludesJSON(t *testing.T) {
 			}
 
 			if !bytes.Equal(junitBytes, tc.expect) {
-				t.Errorf("Expected\n\t%v\n\tbut got\n\t%v",
+				t.Errorf(
+					"Expected\n\t%v\n\tbut got\n\t%v",
 					string(tc.expect),
 					string(junitBytes),
 				)
@@ -393,7 +394,8 @@ func TestControls_ASFF(t *testing.T) {
 						ID:   "g1",
 						Text: "Group text",
 						Checks: []*Check{
-							{ID: "check1id",
+							{
+								ID:             "check1id",
 								Text:           "check1text",
 								State:          FAIL,
 								Remediation:    "fix me",
@@ -403,7 +405,8 @@ func TestControls_ASFF(t *testing.T) {
 							},
 						},
 					},
-				}},
+				},
+			},
 			want: []types.AwsSecurityFinding{
 				{
 					AwsAccountId:  aws.String("foo account"),

--- a/check/test.go
+++ b/check/test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/client-go/util/jsonpath"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
-	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 	k8s.io/apimachinery v0.36.3
@@ -72,7 +72,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
@@ -83,6 +82,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,9 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Migrate the `YAML` dependency from `gopkg.in/yaml.v2` to `go.yaml.in/yaml/v3`

`gopkg.in/yaml` has been archived and `go.yaml.in/yaml/v3` is the maintained gomodule by yaml org itself.

Reference: https://github.com/yaml/go-yaml/