### PR TITLE
fix: support space-separated flag values in audit checks

### DIFF
--- a/check/test.go
+++ b/check/test.go
@@ -138,6 +138,8 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 		if len(vals) > 0 {
 			if vals[3] != "" {
 				value = vals[3]
+			} else if v, ok := t.spaceSeparatedValue(s); ok {
+				value = v
 			} else {
 				// --bool-flag
 				if strings.HasPrefix(t.Flag, "--") {
@@ -153,6 +155,25 @@ func (t flagTestItem) findValue(s string) (match bool, value string, err error) 
 	glog.V(3).Infof("In flagTestItem.findValue %s", value)
 
 	return match, value, err
+}
+
+// spaceSeparatedValue handles flags written as "--flag value" rather than
+// "--flag=value". Whether such a flag takes a value cannot be decided from the
+// command line alone -- "--bool-flag next" looks identical -- so the
+// space-separated form is only read when the test compares against a value.
+// A following token that itself starts with "-" is the next flag rather than a
+// value, so it is left alone and the flag keeps its boolean reading.
+func (t flagTestItem) spaceSeparatedValue(s string) (string, bool) {
+	if t.Compare.Op == "" {
+		return "", false
+	}
+
+	re := regexp.MustCompile(regexp.QuoteMeta(t.Flag) + `\s+([^\s-][^\s]*)`)
+	if m := re.FindStringSubmatch(s); len(m) > 1 {
+		return m[1], true
+	}
+
+	return "", false
 }
 
 func (t pathTestItem) findValue(s string) (match bool, value string, err error) {

--- a/check/test_test.go
+++ b/check/test_test.go
@@ -1405,3 +1405,53 @@ func TestExecuteJSONPathOnEncryptionConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestFlagTestItemFindValueSpaceSeparator(t *testing.T) {
+	cases := []struct {
+		name      string
+		item      testItem
+		str       string
+		wantValue string
+	}{
+		{
+			name:      "space separated value is read when the test compares a value",
+			item:      testItem{Flag: "--metrics-bind-address", Compare: compare{Op: "eq", Value: "127.0.0.1"}},
+			str:       "1:23 /usr/bin/ovnkube --metrics-bind-address 127.0.0.1 --loglevel=4",
+			wantValue: "127.0.0.1",
+		},
+		{
+			name:      "equals separated value keeps working",
+			item:      testItem{Flag: "--metrics-bind-address", Compare: compare{Op: "eq", Value: "127.0.0.1"}},
+			str:       "1:23 /usr/bin/ovnkube --metrics-bind-address=127.0.0.1",
+			wantValue: "127.0.0.1",
+		},
+		{
+			name:      "a following flag is not taken as the value",
+			item:      testItem{Flag: "--profiling", Compare: compare{Op: "eq", Value: "true"}},
+			str:       "1:23 ../kubernetes/kube-apiserver --profiling --secure-port=0",
+			wantValue: "true",
+		},
+		{
+			name:      "presence-only test is unchanged by a following token",
+			item:      testItem{Flag: "--profiling", Set: true},
+			str:       "1:23 ../kubernetes/kube-apiserver --profiling somethingelse",
+			wantValue: "true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ft := flagTestItem(c.item)
+			match, value, err := ft.findValue(c.str)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !match {
+				t.Fatalf("expected %q to match %q", c.item.Flag, c.str)
+			}
+			if value != c.wantValue {
+				t.Errorf("got value %q, want %q", value, c.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2095

## Problem

`flagTestItem.findValue` matches flags with this pattern:

```go
pttn := `(` + t.Flag + `)(=|: *)*([^\s]*) *`
```

The separator alternatives are `=` and `:`, so for `--metrics-bind-address 127.0.0.1` the value group captures nothing, the flag is read as a boolean, and `value` becomes `"true"`. Any `compare` against the real value then fails, which is what the issue reports for `ovnkube`.

## Change

When the flag matches but no value was captured, also try the space-separated form.

Two constraints keep this from changing existing results:

- **Only when the test compares a value** (`t.Compare.Op != ""`). Whether a flag takes a value can't be decided from a command line alone — `--bool-flag next` and `--valued-flag next` are indistinguishable — so a presence-only check keeps its previous `"true"` reading.
- **A following token starting with `-` is not a value.** `--profiling --secure-port=0` still reads as `true` rather than picking up `--secure-port=0`.

A value beginning with `-` (e.g. a negative number) is therefore not picked up; that seemed the right trade against misreading the next flag as a value.

## Tests

New `TestFlagTestItemFindValueSpaceSeparator` in `check/test_test.go` covers the reported case plus three guards.

Verified the test actually pins the behaviour — with `check/test.go` reverted to its current state on `main`:

```
--- FAIL: .../space_separated_value_is_read_when_the_test_compares_a_value
    test_test.go:1453: got value "true", want "127.0.0.1"
--- PASS: .../equals_separated_value_keeps_working
--- PASS: .../a_following_flag_is_not_taken_as_the_value
--- PASS: .../presence-only_test_is_unchanged_by_a_following_token
```

and with the change applied, all four pass, along with the rest of the package:

```
ok  	github.com/aquasecurity/kube-bench/check	1.005s
```
