### PR TITLE
add --override-file to patch individual benchmark tests

### DIFF
--- a/check/controls.go
+++ b/check/controls.go
@@ -95,6 +95,47 @@ func NewControls(t NodeType, in []byte, detectedVersion string) (*Controls, erro
 	return c, nil
 }
 
+// overrides holds a set of check definitions that replace matching checks in a
+// benchmark, keyed by check id.
+type overrides struct {
+	Checks []*Check `yaml:"checks"`
+}
+
+// ApplyOverrides replaces any check whose id matches an entry in the override
+// data with the override definition. Checks that aren't listed are left as they
+// are, so an override file only needs to contain the checks you want to change
+// rather than a copy of the whole benchmark. An empty override leaves the
+// controls untouched.
+func (controls *Controls) ApplyOverrides(in []byte) error {
+	o := new(overrides)
+	if err := yaml.Unmarshal(in, o); err != nil {
+		return fmt.Errorf("failed to unmarshal overrides: %s", err)
+	}
+
+	byID := make(map[string]*Check, len(o.Checks))
+	for _, c := range o.Checks {
+		if c == nil || c.ID == "" {
+			continue
+		}
+		byID[c.ID] = c
+	}
+
+	if len(byID) == 0 {
+		return nil
+	}
+
+	for _, group := range controls.Groups {
+		for i, chk := range group.Checks {
+			if ov, ok := byID[chk.ID]; ok {
+				group.Checks[i] = ov
+				glog.V(1).Infof("overriding check %s", chk.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
 // RunChecks runs the checks with the given Runner. Only checks for which the filter Predicate returns `true` will run.
 func (controls *Controls) RunChecks(runner Runner, filter Predicate, skipIDMap map[string]bool) Summary {
 	var g []*Group

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -462,3 +462,73 @@ func TestControls_ASFF(t *testing.T) {
 		})
 	}
 }
+
+func TestControls_ApplyOverrides(t *testing.T) {
+	base := []byte(`
+---
+type: "master"
+groups:
+- id: G1
+  checks:
+  - id: G1/C1
+    text: "original text"
+    scored: true
+    remediation: "original remediation"
+  - id: G1/C2
+    text: "untouched"
+    scored: true
+`)
+
+	t.Run("Replaces matching checks and leaves others alone", func(t *testing.T) {
+		controls, err := NewControls(MASTER, base, "")
+		assert.NoError(t, err)
+
+		override := []byte(`
+checks:
+- id: G1/C1
+  text: "patched text"
+  scored: false
+  remediation: "patched remediation"
+`)
+		err = controls.ApplyOverrides(override)
+		assert.NoError(t, err)
+
+		c1 := controls.Groups[0].Checks[0]
+		assert.Equal(t, "patched text", c1.Text)
+		assert.Equal(t, false, c1.Scored)
+		assert.Equal(t, "patched remediation", c1.Remediation)
+
+		c2 := controls.Groups[0].Checks[1]
+		assert.Equal(t, "untouched", c2.Text)
+		assert.Equal(t, true, c2.Scored)
+	})
+
+	t.Run("Empty override leaves controls unchanged", func(t *testing.T) {
+		controls, err := NewControls(MASTER, base, "")
+		assert.NoError(t, err)
+
+		err = controls.ApplyOverrides([]byte(""))
+		assert.NoError(t, err)
+
+		c1 := controls.Groups[0].Checks[0]
+		assert.Equal(t, "original text", c1.Text)
+		assert.Equal(t, true, c1.Scored)
+		assert.Equal(t, "original remediation", c1.Remediation)
+	})
+
+	t.Run("Unknown ids in the override are ignored", func(t *testing.T) {
+		controls, err := NewControls(MASTER, base, "")
+		assert.NoError(t, err)
+
+		override := []byte(`
+checks:
+- id: G9/C9
+  text: "does not exist"
+`)
+		err = controls.ApplyOverrides(override)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "original text", controls.Groups[0].Checks[0].Text)
+		assert.Equal(t, "untouched", controls.Groups[0].Checks[1].Text)
+	})
+}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -111,6 +111,16 @@ func runChecks(nodetype check.NodeType, testYamlFile, detectedVersion string) {
 		exitWithError(fmt.Errorf("error setting up %s controls: %v", nodetype, err))
 	}
 
+	if overrideFile != "" {
+		override, err := os.ReadFile(overrideFile)
+		if err != nil {
+			exitWithError(fmt.Errorf("error opening %s override file: %v", overrideFile, err))
+		}
+		if err := controls.ApplyOverrides(override); err != nil {
+			exitWithError(fmt.Errorf("error applying overrides from %s: %v", overrideFile, err))
+		}
+	}
+
 	runner := check.NewRunner()
 	filter, err := NewRunFilter(filterOpts)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ var (
 	filterOpts           FilterOpts
 	includeTestOutput    bool
 	outputFile           string
+	overrideFile         string
 	configFileError      error
 	controlsCollection   []*check.Controls
 )
@@ -173,6 +174,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&skipIds, "skip", "", "List of comma separated values of checks to be skipped")
 	RootCmd.PersistentFlags().BoolVar(&includeTestOutput, "include-test-output", false, "Prints the actual result when test fails")
 	RootCmd.PersistentFlags().StringVar(&outputFile, "outputfile", "", "Writes the results to output file when run with --json or --junit")
+	RootCmd.PersistentFlags().StringVar(&overrideFile, "override-file", "", "YAML file with check definitions that override matching checks (by id) in the benchmark")
 
 	RootCmd.PersistentFlags().StringVarP(
 		&filterOpts.CheckList,

--- a/docs/flags-and-commands.md
+++ b/docs/flags-and-commands.md
@@ -24,6 +24,7 @@ Flag | Description
 --noresults | Disable printing of results section to stdout.
 --nototals | Disable calculating and printing of totals for failed, passed, ... checks across all sections 
 --outputfile | Writes the results to output file when run with --json or --junit
+--override-file | YAML file with check definitions that override matching checks (by id) in the benchmark. See [Overriding individual tests](#overriding-individual-tests).
 --pgsql | Save the results to PostgreSQL
 --scored | Run the scored CIS checks (default true)
 --skip string | List of comma separated values of checks to be skipped
@@ -96,6 +97,26 @@ as a comma-delimited list on the command line with the `--skip` flag.
 `kube-bench --skip="1.1,1.2.1,1.3.3"`
 Will skip 1.1.X group and individual checks 1.2.1, 1.3.3.
 Skipped checks returns [INFO] output. 
+
+#### Overriding individual tests
+
+If you only need to change a handful of tests for your environment, you can point `kube-bench` at an override file instead of copying and maintaining a whole benchmark directory.
+
+`kube-bench --override-file myoverrides.yaml`
+
+The override file is a small YAML file with a `checks` list. Any check whose `id` matches an entry in the list is replaced by the definition in the override file; checks that aren't listed run unchanged. This works with the top-level command as well as `kube-bench run`, so the same file can carry overrides for any target (master, node, etcd, ...).
+
+```yaml
+checks:
+- id: 1.2.1
+  text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+  type: manual
+  scored: false
+  remediation: |
+    We accept the risk of anonymous auth in this cluster.
+```
+
+Each override entry is a full check definition (the same schema used in the benchmark files under `cfg/`), so include all of the fields you want the check to end up with, not just the ones you're changing.
 
 #### Exit code
 


### PR DESCRIPTION
Adds an `--override-file` flag so you can patch a few benchmark tests for your environment without copying and maintaining a whole `cfg/<version>` directory. Closes #571.

The override file is a small YAML file with a `checks` list. After the benchmark loads, any check whose `id` matches an entry in the list gets replaced by the override definition; checks that aren't listed run unchanged, and with no `--override-file` behavior is exactly as before. It's wired into `runChecks`, so it applies to both the top-level command and `kube-bench run`, and a single file can carry overrides for any target (master, node, etcd, ...) since matching is by id.

Example:

```
kube-bench --override-file myoverrides.yaml
```

```yaml
checks:
- id: 1.2.1
  text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
  type: manual
  scored: false
  remediation: |
    We accept the risk of anonymous auth in this cluster.
```

On the semantics: I went with whole-check replace keyed by `id` (an override entry is a full check definition, same schema as the `cfg/` files) rather than a field-level deep merge. It's the simplest thing to reason about and keeps the override schema identical to what people already know from editing the shipped files. If you'd rather have field-level patch (e.g. only set `scored: false` and inherit the rest) I'm happy to switch it, just wanted to keep the first cut small.

Tests: added `TestControls_ApplyOverrides` covering a matching check getting replaced while a sibling is untouched, an empty override leaving controls unchanged, and unknown ids being ignored.

```
$ go test ./check/... ./cmd/...
ok      github.com/aquasecurity/kube-bench/check        2.719s
ok      github.com/aquasecurity/kube-bench/cmd          10.175s

$ go test ./check/... -run TestControls_ApplyOverrides -v
--- PASS: TestControls_ApplyOverrides (0.00s)
    --- PASS: TestControls_ApplyOverrides/Replaces_matching_checks_and_leaves_others_alone (0.00s)
    --- PASS: TestControls_ApplyOverrides/Empty_override_leaves_controls_unchanged (0.00s)
    --- PASS: TestControls_ApplyOverrides/Unknown_ids_in_the_override_are_ignored (0.00s)
PASS
```

Docs updated in `docs/flags-and-commands.md` (flag table + an "Overriding individual tests" section).
