### PR TITLE
fix: 4.6.3 default-namespace check false positive with resource/name kubectl output

### DIFF
--- a/cfg/aks-1.7/policies.yaml
+++ b/cfg/aks-1.7/policies.yaml
@@ -394,7 +394,7 @@ groups:
       - id: 4.6.3
         text: "The default namespace should not be used (Automated)"
         audit: |
-          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -v '^service\s\+kubernetes\s' || true)
+          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]' || true)
           if [ -z "$output" ]; then echo "DEFAULT_NAMESPACE_UNUSED"; else echo "DEFAULT_NAMESPACE_IN_USE"; fi
         tests:
           test_items:

--- a/cfg/aks-1.8/policies.yaml
+++ b/cfg/aks-1.8/policies.yaml
@@ -307,7 +307,7 @@ groups:
       - id: 4.6.3
         text: "The default namespace should not be used (Automated)"
         audit: |
-          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -v '^service\s\+kubernetes\s' || true)
+          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]' || true)
           if [ -z "$output" ]; then echo "DEFAULT_NAMESPACE_UNUSED"; else echo "DEFAULT_NAMESPACE_IN_USE"; fi
         tests:
           test_items:

--- a/cfg/gke-1.8.0/policies.yaml
+++ b/cfg/gke-1.8.0/policies.yaml
@@ -458,7 +458,7 @@ groups:
       - id: 4.6.4
         text: "The default namespace should not be used (Automated)"
         audit: |
-          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -v '^service\s\+kubernetes\s' || true)
+          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]' || true)
           if [ -z "$output" ]; then echo "DEFAULT_NAMESPACE_UNUSED"; else echo "DEFAULT_NAMESPACE_IN_USE"; fi
         tests:
           test_items:

--- a/cfg/gke-1.9.0/policies.yaml
+++ b/cfg/gke-1.9.0/policies.yaml
@@ -496,7 +496,7 @@ groups:
       - id: 4.6.4
         text: "The default namespace should not be used (Manual)"
         audit: |
-          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -v '^service\s\+kubernetes\s' || true)
+          output=$(kubectl get all -n default --no-headers 2>/dev/null | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]' || true)
           if [ -z "$output" ]; then echo "DEFAULT_NAMESPACE_UNUSED"; else echo "DEFAULT_NAMESPACE_IN_USE"; fi
         tests:
           test_items:


### PR DESCRIPTION
Fixes #2145

Check 4.6.3 "The default namespace should not be used" runs `kubectl get all -n default --no-headers` and tries to drop the built-in API Service with `grep -v '^service\s\+kubernetes\s'`. With multiple resource types requested, kubectl prints rows in `resource/name` form, so the line is `service/kubernetes   ClusterIP ...`, the exclusion never matches, and the Service itself counts as usage. The check then FAILs on every cluster, including ones with an otherwise empty `default` namespace.

This changes the filter to accept both the `resource/name` form and the legacy column form, using POSIX character classes so it behaves the same under the busybox `grep` in the kube-bench image. Same one-line change in the four profiles that share this audit: `aks-1.7`, `aks-1.8`, `gke-1.8.0`, `gke-1.9.0`.

**Before** (AKS 1.34, kube-bench v0.16.0, `default` namespace holding only `service/kubernetes`):

```
$ kubectl get all -n default --no-headers
service/kubernetes   ClusterIP   10.1.0.1   <none>   443/TCP   102d

[FAIL] 4.6.3 The default namespace should not be used (Automated)   actual_value: DEFAULT_NAMESPACE_IN_USE
```

**After**, the new filter run inside the kube-bench image against the same input plus the two other cases:

```
$ printf '%s\n' 'service/kubernetes   ClusterIP   10.1.0.1   <none>   443/TCP   102d' | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]'; echo $?
1        # built-in service filtered -> DEFAULT_NAMESPACE_UNUSED -> PASS

$ printf '%s\n' 'service   kubernetes   ClusterIP   10.1.0.1' | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]'; echo $?
1        # legacy column form still filtered

$ printf '%s\n' 'deployment.apps/my-app   1/1   1   1   3d' | grep -Ev '^service(/|[[:space:]]+)kubernetes[[:space:]]'; echo $?
deployment.apps/my-app   1/1   1   1   3d
0        # real workloads still detected -> FAIL as intended
```
